### PR TITLE
Strongly typed app settings

### DIFF
--- a/coffeecard/CoffeeCard.Tests.Integration/CoffeeCard.Tests.Integration.csproj
+++ b/coffeecard/CoffeeCard.Tests.Integration/CoffeeCard.Tests.Integration.csproj
@@ -14,6 +14,7 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+		<PackageReference Include="NetEscapades.Configuration.Validation" Version="2.0.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
 		<PackageReference Include="coverlet.collector" Version="1.2.0" />

--- a/coffeecard/CoffeeCard.Tests.Unit/Helpers/MobilePayApiHttpClientTests.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Helpers/MobilePayApiHttpClientTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Net.Http;
+using CoffeeCard.Configuration;
 using CoffeeCard.Helpers.MobilePay;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -15,10 +16,10 @@ namespace CoffeeCard.Tests.Unit.Helpers
         {
             var testCertificateName = "testCertificate.pfx";
 
-            var configuration = new Mock<IConfiguration>();
-            configuration.Setup(c => c["CertificatePassword"]).Returns("password");
-            configuration.Setup(c => c["MPSubscriptionKey"]).Returns("subscrpKey");
-            configuration.Setup(c => c["MobilePayAPI-CertificateName"]).Returns(testCertificateName);
+            var mobilePaySettings = new Mock<MobilePaySettings>();
+            mobilePaySettings.Setup(c => c.CertificatePassword).Returns("password");
+            mobilePaySettings.Setup(c => c.SubscriptionKey).Returns("subscrpKey");
+            mobilePaySettings.Setup(c => c.CertificateName).Returns(testCertificateName);
 
             var directoryContents = new Mock<IDirectoryContents>();
             directoryContents.Setup(dc => dc.FirstOrDefault(f => f.Name.Equals(testCertificateName)).PhysicalPath)
@@ -33,7 +34,7 @@ namespace CoffeeCard.Tests.Unit.Helpers
             var httpClient = new Mock<HttpClient>();
 
             var mobileApiHttpClient =
-                new MobilePayApiHttpClient(httpClient.Object, configuration.Object, environment.Object);
+                new MobilePayApiHttpClient(httpClient.Object, environment.Object, mobilePaySettings.Object);
         }
     }
 }

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/MobilePayServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/MobilePayServiceTest.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Threading.Tasks;
+using CoffeeCard.Configuration;
 using CoffeeCard.Helpers.MobilePay;
 using CoffeeCard.Helpers.MobilePay.ErrorMessage;
 using CoffeeCard.Helpers.MobilePay.RequestMessage;
@@ -17,9 +18,10 @@ namespace CoffeeCard.Tests.Unit.Services
         public async Task CancelPaymentReservationGivenOrderIdCallsMobilePayApiHttpClient()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var requestMessage = new CancelReservationRequest("merchantID", "1234");
@@ -32,7 +34,7 @@ namespace CoffeeCard.Tests.Unit.Services
                         TransactionId = "transId"
                     });
 
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Act
             await mobilePayService.CancelPaymentReservation("1234");
@@ -50,9 +52,10 @@ namespace CoffeeCard.Tests.Unit.Services
             CancelPaymentReservationRethrowsExceptionWhenMobilePayApiHttpClientThrowsAMobilePayExceptionWithUnauthorizedStatusCode()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var requestMessage = new CancelReservationRequest("merchantID", "1234");
@@ -66,7 +69,7 @@ namespace CoffeeCard.Tests.Unit.Services
                     }, HttpStatusCode.Unauthorized));
 
             // Act
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Assert
             await Assert.ThrowsAsync<MobilePayException>(() => mobilePayService.CancelPaymentReservation("1234"));
@@ -78,9 +81,10 @@ namespace CoffeeCard.Tests.Unit.Services
             CancelPaymentReservationRetriesWhenMobilePayApiHttpClientThrowsAMobilePayExceptionWithRequestTimeOutStatusCode()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var requestMessage = new CancelReservationRequest("merchantID", "1234");
@@ -108,7 +112,7 @@ namespace CoffeeCard.Tests.Unit.Services
                     });
 
 
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Act
             await mobilePayService.CancelPaymentReservation("1234");
@@ -126,9 +130,10 @@ namespace CoffeeCard.Tests.Unit.Services
         public async Task CapturePaymentGivenOrderIdCallsMobilePayApiHttpClient()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var requestMessage = new CaptureAmountRequest("merchantID", "1234");
@@ -141,7 +146,7 @@ namespace CoffeeCard.Tests.Unit.Services
                         TransactionId = "transId"
                     });
 
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Act
             await mobilePayService.CapturePayment("1234");
@@ -159,9 +164,10 @@ namespace CoffeeCard.Tests.Unit.Services
             CapturePaymentRethrowsExceptionWhenMobilePayApiHttpClientThrowsAMobilePayExceptionWithUnauthorizedStatusCode()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var requestMessage = new CaptureAmountRequest("merchantID", "1234");
@@ -175,7 +181,7 @@ namespace CoffeeCard.Tests.Unit.Services
                     }, HttpStatusCode.Unauthorized));
 
             // Act
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Assert
             await Assert.ThrowsAsync<MobilePayException>(() => mobilePayService.CapturePayment("1234"));
@@ -187,9 +193,10 @@ namespace CoffeeCard.Tests.Unit.Services
             CapturePaymentRetriesWhenMobilePayApiHttpClientThrowsAMobilePayExceptionWithRequestTimeOutStatusCode()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var requestMessage = new CaptureAmountRequest("merchantID", "1234");
@@ -217,7 +224,7 @@ namespace CoffeeCard.Tests.Unit.Services
                     });
 
 
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Act
             await mobilePayService.CapturePayment("1234");
@@ -235,9 +242,10 @@ namespace CoffeeCard.Tests.Unit.Services
         public async Task GetPaymentStatusGivenOrderIdCallsMobilePayApiHttpClient()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var mobilePayApiRequestMessage = new GetPaymentStatusRequest("merchantID", "1234");
@@ -252,7 +260,7 @@ namespace CoffeeCard.Tests.Unit.Services
                         TransactionId = "transId"
                     });
 
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Act
             await mobilePayService.GetPaymentStatus("1234");
@@ -270,9 +278,10 @@ namespace CoffeeCard.Tests.Unit.Services
             GetPaymentStatusRethrowsExceptionWhenMobilePayApiHttpClientThrowsAMobilePayExceptionWithUnauthorizedStatusCode()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var mobilePayApiRequestMessage = new GetPaymentStatusRequest("merchantID", "1234");
@@ -286,7 +295,7 @@ namespace CoffeeCard.Tests.Unit.Services
                     }, HttpStatusCode.Unauthorized));
 
             // Act
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Assert
             await Assert.ThrowsAsync<MobilePayException>(() => mobilePayService.GetPaymentStatus("1234"));
@@ -298,9 +307,10 @@ namespace CoffeeCard.Tests.Unit.Services
             GetPaymentStatusRetriesWhenMobilePayApiHttpClientThrowsAMobilePayExceptionWithRequestTimeOutStatusCode()
         {
             // Arrange
-            var configuration = new Mock<IConfiguration>();
-
-            configuration.Setup(c => c["MPMerchantID"]).Returns("merchantID");
+            var mobilePaySettings = new MobilePaySettings
+            {
+                MerchantId = "merchantID"
+            };
 
             var mobilePayApiClient = new Mock<IMobilePayApiHttpClient>();
             var mobilePayApiRequestMessage = new GetPaymentStatusRequest("merchantID", "1234");
@@ -322,7 +332,7 @@ namespace CoffeeCard.Tests.Unit.Services
                         TransactionId = "transId"
                     });
 
-            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, configuration.Object);
+            var mobilePayService = new MobilePayService(mobilePayApiClient.Object, mobilePaySettings);
 
             // Act
             await mobilePayService.GetPaymentStatus("1234");

--- a/coffeecard/CoffeeCard/CoffeeCard.csproj
+++ b/coffeecard/CoffeeCard/CoffeeCard.csproj
@@ -37,6 +37,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
+		<PackageReference Include="NetEscapades.Configuration.Validation" Version="2.0.0" />
 		<PackageReference Include="NSwag.AspNetCore" Version="13.2.3" />
 		<PackageReference Include="RestSharp" Version="106.10.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/coffeecard/CoffeeCard/Configuration/DatabaseSettings.cs
+++ b/coffeecard/CoffeeCard/Configuration/DatabaseSettings.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+using NetEscapades.Configuration.Validation;
+
+namespace CoffeeCard.Configuration
+{
+    public class DatabaseSettings : IValidatable
+    {
+        [Required]
+        public string ConnectionString { get; set; }
+        [Required]
+        public string SchemaName { get; set; }
+
+        public void Validate()
+        {
+            Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard/Configuration/EnvironmentSettings.cs
+++ b/coffeecard/CoffeeCard/Configuration/EnvironmentSettings.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using NetEscapades.Configuration.Validation;
+
+namespace CoffeeCard.Configuration
+{
+    public class EnvironmentSettings : IValidatable
+    {
+        [Required]
+        public EnvironmentType EnvironmentType { get; set; }
+        [Required]
+        public string MinAppVersion { get; set; }
+
+        public void Validate()
+        {
+            Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+        }
+    }
+
+    public enum EnvironmentType { Production, Test }
+}

--- a/coffeecard/CoffeeCard/Configuration/IdentitySettings.cs
+++ b/coffeecard/CoffeeCard/Configuration/IdentitySettings.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+using NetEscapades.Configuration.Validation;
+
+namespace CoffeeCard.Configuration
+{
+    public class IdentitySettings : IValidatable
+    {
+        [Required]
+        public string TokenKey { get; set; }
+        [Required]
+        public string AdminToken { get; set; }
+
+        public void Validate()
+        {
+            Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard/Configuration/MailgunSettings.cs
+++ b/coffeecard/CoffeeCard/Configuration/MailgunSettings.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+using NetEscapades.Configuration.Validation;
+
+namespace CoffeeCard.Configuration
+{
+    public class MailgunSettings : IValidatable
+    {
+        [Required]
+        public string ApiKey { get; set; }
+        [Required]
+        public string Domain { get; set; }
+        [Required]
+        public string EmailBaseUrl { get; set; }
+
+        public void Validate()
+        {
+            Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard/Configuration/MobilePaySettings.cs
+++ b/coffeecard/CoffeeCard/Configuration/MobilePaySettings.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using NetEscapades.Configuration.Validation;
+
+namespace CoffeeCard.Configuration
+{
+    public class MobilePaySettings : IValidatable
+    {
+        [Required]
+        public string MerchantId { get; set; }
+        [Required]
+        public string SubscriptionKey { get; set; }
+        [Required]
+        public string CertificateName { get; set; }
+        [Required]
+        public string CertificatePassword { get; set; }
+
+        public void Validate()
+        {
+            Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard/Controllers/PurchasesController.cs
+++ b/coffeecard/CoffeeCard/Controllers/PurchasesController.cs
@@ -1,10 +1,12 @@
 ﻿using System.Linq;
+using CoffeeCard.Configuration;
 using CoffeeCard.Helpers;
 using CoffeeCard.Models.DataTransferObjects.Purchase;
 using CoffeeCard.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Serilog;
 
 namespace CoffeeCard.Controllers
@@ -15,18 +17,18 @@ namespace CoffeeCard.Controllers
     [ApiController]
     public class PurchasesController : ControllerBase
     {
-        private readonly IConfiguration _configuration;
+        private readonly IdentitySettings _identitySettings;
         private readonly IMapperService _mapperService;
         private readonly IPurchaseService _purchaseService;
         private IAccountService _accountService;
 
         public PurchasesController(IPurchaseService purchaseService, IMapperService mapper,
-            IAccountService accountService, IConfiguration configuration)
+            IAccountService accountService, IdentitySettings identitySettings)
         {
             _purchaseService = purchaseService;
             _mapperService = mapper;
             _accountService = accountService;
-            _configuration = configuration;
+            _identitySettings = identitySettings;
         }
 
         /// <summary>
@@ -60,7 +62,7 @@ namespace CoffeeCard.Controllers
         {
             var adminToken = Request.Headers.FirstOrDefault(x => x.Key == "admintoken").Value.FirstOrDefault();
             Log.Information(adminToken);
-            if (adminToken != _configuration["AdminToken"]) throw new ApiException("AdminToken was invalid", 401);
+            if (adminToken != _identitySettings.AdminToken) throw new ApiException("AdminToken was invalid", 401);
             var purchase = _purchaseService.IssueProduct(issueProduct);
             return Ok(_mapperService.Map(purchase));
         }

--- a/coffeecard/CoffeeCard/Migrations/20191012125617_Initial - test.Designer.cs
+++ b/coffeecard/CoffeeCard/Migrations/20191012125617_Initial - test.Designer.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace coffeecard.Migrations
 {
-    [DbContext(typeof(CoffeecardContext))]
+    [DbContext(typeof(CoffeeCardContext))]
     [Migration("20191012125617_Initial - test")]
     partial class Initialtest
     {

--- a/coffeecard/CoffeeCard/Migrations/CoffeecardContextModelSnapshot.cs
+++ b/coffeecard/CoffeeCard/Migrations/CoffeecardContextModelSnapshot.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace CoffeeCard.Migrations
 {
-    [DbContext(typeof(CoffeecardContext))]
+    [DbContext(typeof(CoffeeCardContext))]
     internal class CoffeecardContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/coffeecard/CoffeeCard/Models/CoffeecardContext.cs
+++ b/coffeecard/CoffeeCard/Models/CoffeecardContext.cs
@@ -1,16 +1,18 @@
+using CoffeeCard.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace CoffeeCard.Models
 {
-    public class CoffeecardContext : DbContext
+    public class CoffeeCardContext : DbContext
     {
-        private readonly IConfiguration _configuration;
+        private readonly DatabaseSettings _databaseSettings;
 
-        public CoffeecardContext(DbContextOptions<CoffeecardContext> options, IConfiguration configuration)
+        public CoffeeCardContext(DbContextOptions<CoffeeCardContext> options, DatabaseSettings databaseSettings)
             : base(options)
         {
-            _configuration = configuration;
+            _databaseSettings = databaseSettings;
         }
 
         public DbSet<User> Users { get; set; }
@@ -25,7 +27,7 @@ namespace CoffeeCard.Models
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasDefaultSchema(_configuration["databaseSchema"]);
+            modelBuilder.HasDefaultSchema(_databaseSettings.SchemaName);
         }
     }
 }

--- a/coffeecard/CoffeeCard/Models/DataTransferObjects/AppConfig/AppConfigDTO.cs
+++ b/coffeecard/CoffeeCard/Models/DataTransferObjects/AppConfig/AppConfigDTO.cs
@@ -1,8 +1,10 @@
-﻿namespace CoffeeCard.Models.DataTransferObjects.AppConfig
+﻿using CoffeeCard.Configuration;
+
+namespace CoffeeCard.Models.DataTransferObjects.AppConfig
 {
     public class AppConfigDTO
     {
-        public string EnvironmentType { get; set; }
+        public EnvironmentType EnvironmentType { get; set; }
         public string MerchantId { get; set; }
     }
 }

--- a/coffeecard/CoffeeCard/Program.cs
+++ b/coffeecard/CoffeeCard/Program.cs
@@ -12,9 +12,6 @@ namespace CoffeeCard
 		public static IConfiguration Configuration { get; } = new ConfigurationBuilder()
 			.SetBasePath(Directory.GetCurrentDirectory())
 			.AddJsonFile("appsettings.json", false, true)
-			.AddJsonFile(
-				$"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json",
-				true)
 			.Build();
 
 		public static int Main(string[] args)

--- a/coffeecard/CoffeeCard/Services/AccountService.cs
+++ b/coffeecard/CoffeeCard/Services/AccountService.cs
@@ -3,36 +3,35 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
+using CoffeeCard.Configuration;
 using CoffeeCard.Helpers;
 using CoffeeCard.Models;
 using CoffeeCard.Models.DataTransferObjects.User;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Serilog;
 
 namespace CoffeeCard.Services
 {
     public class AccountService : IAccountService
     {
-        private readonly IConfiguration _configuration;
-        private readonly CoffeecardContext _context;
+        private readonly EnvironmentSettings _environmentSettings;
+        private readonly CoffeeCardContext _context;
         private readonly IEmailService _emailService;
         private readonly IHashService _hashService;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly IPurchaseService _purchaseService;
         private readonly ITokenService _tokenService;
 
-        public AccountService(CoffeecardContext context, IConfiguration configuration, ITokenService tokenService,
-            IEmailService emailService, IHashService hashService, IPurchaseService purchaseService,
-            IHttpContextAccessor httpContextAccessor)
+        public AccountService(CoffeeCardContext context, EnvironmentSettings environmentSettings, ITokenService tokenService,
+            IEmailService emailService, IHashService hashService, IHttpContextAccessor httpContextAccessor)
         {
             _context = context;
-            _configuration = configuration;
+            _environmentSettings = environmentSettings;
             _tokenService = tokenService;
             _emailService = emailService;
             _hashService = hashService;
-            _purchaseService = purchaseService;
             _httpContextAccessor = httpContextAccessor;
         }
 
@@ -262,7 +261,7 @@ namespace CoffeeCard.Services
 
                 var versionSum = major + minor;
 
-                var requiredMatch = regex.Match(_configuration["MinAppVersion"]);
+                var requiredMatch = regex.Match(_environmentSettings.MinAppVersion);
                 var requiredMajor = int.Parse(requiredMatch.Groups[1].Value.TrimEnd('.'));
                 var requiredMinor = int.Parse(requiredMatch.Groups[2].Value.TrimEnd('.'));
 

--- a/coffeecard/CoffeeCard/Services/AppConfigService.cs
+++ b/coffeecard/CoffeeCard/Services/AppConfigService.cs
@@ -1,24 +1,27 @@
 ﻿using System;
+using CoffeeCard.Configuration;
 using CoffeeCard.Models.DataTransferObjects.AppConfig;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace CoffeeCard.Services
 {
     public class AppConfigService : IAppConfigService
     {
-        private readonly IConfiguration _configuration;
+        private readonly MobilePaySettings _mobilePaySettings;
+        private readonly EnvironmentSettings _environmentSettings;
 
-        public AppConfigService(IConfiguration configuration)
+        public AppConfigService(IOptions<MobilePaySettings> mobilePaySettings, EnvironmentSettings environmentSettings)
         {
-            _configuration = configuration;
+            _mobilePaySettings = mobilePaySettings.Value;
+            _environmentSettings = environmentSettings;
         }
 
         public AppConfigDTO RetreiveConfiguration()
         {
-            var _environmentType = _configuration["EnvironmentType"];
-            var _merchantId = _configuration["MPMerchantID"];
-            if (string.IsNullOrEmpty(_environmentType) || string.IsNullOrEmpty(_merchantId))
-                throw new ArgumentNullException();
+            var _environmentType = _environmentSettings.EnvironmentType;
+            var _merchantId =_mobilePaySettings.MerchantId;
+
             return new AppConfigDTO
             {
                 EnvironmentType = _environmentType,

--- a/coffeecard/CoffeeCard/Services/EmailService.cs
+++ b/coffeecard/CoffeeCard/Services/EmailService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using CoffeeCard.Configuration;
 using CoffeeCard.Models;
 using CoffeeCard.Models.DataTransferObjects.Purchase;
 using CoffeeCard.Models.DataTransferObjects.User;
@@ -7,6 +8,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using MimeKit;
 using RestSharp;
 using RestSharp.Authenticators;
@@ -16,14 +18,14 @@ namespace CoffeeCard.Services
 {
     public class EmailService : IEmailService
     {
-        private readonly IConfiguration _configuration;
+        private readonly MailgunSettings _mailgunSettings;
         private readonly IHostingEnvironment _env;
         private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public EmailService(IConfiguration configuration, IHostingEnvironment env,
+        public EmailService(MailgunSettings mailgunSettings, IHostingEnvironment env,
             IHttpContextAccessor httpContextAccessor)
         {
-            _configuration = configuration;
+            _mailgunSettings = mailgunSettings;
             _env = env;
             _httpContextAccessor = httpContextAccessor;
         }
@@ -165,9 +167,9 @@ namespace CoffeeCard.Services
             var client = new RestClient();
             client.BaseUrl = new Uri("https://api.mailgun.net/v3");
 
-            client.Authenticator = new HttpBasicAuthenticator("api", _configuration["MailgunAPIKey"]);
+            client.Authenticator = new HttpBasicAuthenticator("api", _mailgunSettings.ApiKey);
             var request = new RestRequest();
-            request.AddParameter("domain", _configuration["MailgunDomain"], ParameterType.UrlSegment);
+            request.AddParameter("domain", _mailgunSettings.Domain, ParameterType.UrlSegment);
             request.Resource = "{domain}/messages";
             request.AddParameter("from", "Cafe Analog <mailgun@cafeanalog.dk>");
             request.AddParameter("to", mail.To[0]);

--- a/coffeecard/CoffeeCard/Services/LeaderboardService.cs
+++ b/coffeecard/CoffeeCard/Services/LeaderboardService.cs
@@ -8,9 +8,9 @@ namespace CoffeeCard.Services
 {
     public class LeaderboardService : ILeaderboardService
     {
-        private readonly CoffeecardContext _context;
+        private readonly CoffeeCardContext _context;
 
-        public LeaderboardService(CoffeecardContext context)
+        public LeaderboardService(CoffeeCardContext context)
         {
             _context = context;
         }

--- a/coffeecard/CoffeeCard/Services/MobilePayService.cs
+++ b/coffeecard/CoffeeCard/Services/MobilePayService.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Threading.Tasks;
+using CoffeeCard.Configuration;
 using CoffeeCard.Helpers.MobilePay;
 using CoffeeCard.Helpers.MobilePay.RequestMessage;
 using CoffeeCard.Helpers.MobilePay.ResponseMessage;
@@ -13,10 +14,10 @@ namespace CoffeeCard.Services
         private readonly string _merchantId;
         private readonly IMobilePayApiHttpClient _mobilePayAPIClient;
 
-        public MobilePayService(IMobilePayApiHttpClient mobilePayAPIClient, IConfiguration configuration)
+        public MobilePayService(IMobilePayApiHttpClient mobilePayAPIClient, MobilePaySettings mobilePaySettings)
         {
             _mobilePayAPIClient = mobilePayAPIClient;
-            _merchantId = configuration["MPMerchantID"];
+            _merchantId = mobilePaySettings.MerchantId;
         }
 
         public async Task<GetPaymentStatusResponse> GetPaymentStatus(string orderId)

--- a/coffeecard/CoffeeCard/Services/ProductService.cs
+++ b/coffeecard/CoffeeCard/Services/ProductService.cs
@@ -6,9 +6,9 @@ namespace CoffeeCard.Services
 {
     public class ProductService : IProductService
     {
-        private readonly CoffeecardContext _context;
+        private readonly CoffeeCardContext _context;
 
-        public ProductService(CoffeecardContext context)
+        public ProductService(CoffeeCardContext context)
         {
             _context = context;
         }

--- a/coffeecard/CoffeeCard/Services/ProgrammeService.cs
+++ b/coffeecard/CoffeeCard/Services/ProgrammeService.cs
@@ -6,9 +6,9 @@ namespace CoffeeCard.Services
 {
     public class ProgrammeService : IProgrammeService
     {
-        private readonly CoffeecardContext _context;
+        private readonly CoffeeCardContext _context;
 
-        public ProgrammeService(CoffeecardContext context)
+        public ProgrammeService(CoffeeCardContext context)
         {
             _context = context;
         }

--- a/coffeecard/CoffeeCard/Services/PurchaseService.cs
+++ b/coffeecard/CoffeeCard/Services/PurchaseService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using CoffeeCard.Configuration;
 using CoffeeCard.Helpers;
 using CoffeeCard.Helpers.MobilePay;
 using CoffeeCard.Helpers.MobilePay.ResponseMessage;
@@ -17,18 +18,18 @@ namespace CoffeeCard.Services
 {
     public class PurchaseService : IPurchaseService
     {
-        private readonly IConfiguration _configuration;
-        private readonly CoffeecardContext _context;
+        private readonly MobilePaySettings _mobilePaySettings;
+        private readonly CoffeeCardContext _context;
         private readonly IEmailService _emailService;
         private readonly IMapperService _mapper;
         private readonly IMobilePayService _mobilePayService;
 
-        public PurchaseService(CoffeecardContext context, IMobilePayService mobilePayService,
-            IConfiguration configuration, IEmailService emailService, IMapperService mapper)
+        public PurchaseService(CoffeeCardContext context, IMobilePayService mobilePayService,
+            MobilePaySettings mobilePaySettings, IEmailService emailService, IMapperService mapper)
         {
             _context = context;
             _mobilePayService = mobilePayService;
-            _configuration = configuration;
+            _mobilePaySettings = mobilePaySettings;
             _emailService = emailService;
             _mapper = mapper;
         }
@@ -223,7 +224,7 @@ namespace CoffeeCard.Services
             try
             {
                 //TODO Figure out the purpose of this check, and probably fix it in regard to test environment
-                if (!_configuration["MPMerchantID"].Equals("APPDK0000000000"))
+                if (!_mobilePaySettings.MerchantId.Equals("APPDK0000000000"))
                 {
                     paymentStatus = await ValidateTransaction(dto);
 

--- a/coffeecard/CoffeeCard/Services/TicketService.cs
+++ b/coffeecard/CoffeeCard/Services/TicketService.cs
@@ -14,9 +14,9 @@ namespace CoffeeCard.Services
     {
         private readonly IAccountService _accountService;
 
-        private readonly CoffeecardContext _context;
+        private readonly CoffeeCardContext _context;
 
-        public TicketService(CoffeecardContext context, IAccountService accountService)
+        public TicketService(CoffeeCardContext context, IAccountService accountService)
         {
             _context = context;
             _accountService = accountService;

--- a/coffeecard/CoffeeCard/Services/TokenService.cs
+++ b/coffeecard/CoffeeCard/Services/TokenService.cs
@@ -3,24 +3,26 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using CoffeeCard.Configuration;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace CoffeeCard.Services
 {
     public class TokenService : ITokenService
     {
-        private readonly IConfiguration _configuration;
+        private readonly IdentitySettings _identitySettings;
 
-        public TokenService(IConfiguration configuration)
+        public TokenService(IdentitySettings identitySettings)
         {
-            _configuration = configuration;
+            _identitySettings = identitySettings;
         }
 
         public string GenerateToken(IEnumerable<Claim> claims)
         {
             var key = new SymmetricSecurityKey(
-                Encoding.UTF8.GetBytes(_configuration["TokenKey"])); // get token from appsettings.json
+                Encoding.UTF8.GetBytes(_identitySettings.TokenKey)); // get token from appsettings.json
 
             var jwt = new JwtSecurityToken("AnalogIO",
                 "Everyone",

--- a/coffeecard/CoffeeCard/appsettings-for-tests.json
+++ b/coffeecard/CoffeeCard/appsettings-for-tests.json
@@ -1,37 +1,45 @@
 {
   "AllowedHosts": "*",
-  "ConnectionStrings": {
-	"CoffeecardDatabase": "None"
+  "EnvironmentSettings": {
+    "EnvironmentType": "Test",
+    "MinAppVersion": "2"
   },
-  "TokenKey": "None",
-  "AdminToken": "None",
-  "EmailBaseUrl": "None",
-  "AnalogFinanceEmail": "None",
-  "MPMerchantID": "None",
-  "MPSubscriptionKey": "None",
-  "MailgunAPIKey": "None",
-  "MailgunDomain": "None",
-  "CertificatePassword": "None",
-  "MobilePayAPI-CertificateName": "None",
-  "MinAppVersion": "2.0.0",
-  "databaseSchema": "None",
-  "EnvironmentType": "None",
+  "DatabaseSettings": {
+    "ConnectionString": "None",
+    "SchemaName": "None"
+  },
+  "IdentitySettings": {
+    "TokenKey": "None",
+    "AdminToken": "None"
+  },
+  "MailgunSettings": {
+    "ApiKey": "None",
+    "Domain": "None",
+    "EmailBaseUrl": "None"
+  },
+  "MobilePaySettings": {
+    "MerchantId": "None",
+    "SubscriptionKey": "None",
+    "CertificateName": "None",
+    "CertificatePassword": "None"
+  },
+
   "Serilog": {
-	"MinimumLevel": {
-	  "Default": "Information",
-	  "Override": {
-		"Microsoft": "Error"
-	  }
-	},
-	"WriteTo": [
-	  {
-		"Name": "File",
-		"Args": {
-		  "path": "logs/log.txt",
-		  "rollingInterval": "Day",
-		  "shared": true
-		}
-	  }
-	]
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Error"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/log.txt",
+          "rollingInterval": "Day",
+          "shared": true
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
- AppSettings are parsed to specialized settings objects instead of reading configuration from strings
- If a settings is `null` at startup, the project will throw an Exception