### PR TITLE
Fix GetSemesterStart

### DIFF
--- a/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
@@ -16,7 +16,7 @@ namespace CoffeeCard.Tests.Unit.Models
         [InlineData("2030/06/30", "2030/01/28")]
         [InlineData("2000/07/01", "2000/07/01")]
         [InlineData("2020/12/31", "2020/07/01")]
-        public void TestSemesterStartGetsLastMondayOfJanuaryInSpring(string currentDateStr, string expectedDateStr)
+        public void TestGetSemesterStart(string currentDateStr, string expectedDateStr)
         {
             var currentDate = DateTime.Parse(currentDateStr);
             var expectedDate = DateTime.Parse(expectedDateStr);

--- a/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
@@ -16,11 +16,8 @@ namespace CoffeeCard.Tests.Unit.Models
         [InlineData("2030/06/30", "2030/01/28")]
         public void TestSemesterStartGetsLastMondayOfJanuaryInSpring(string currentDateStr, string expectedDateStr)
         {
-            var cd = currentDateStr.Split('/');
-            var ed = expectedDateStr.Split('/');
-
-            var currentDate = new DateTime(int.Parse(cd[0]), int.Parse(cd[1]), int.Parse(cd[2]));
-            var expectedDate = new DateTime(int.Parse(ed[0]), int.Parse(ed[1]), int.Parse(ed[2]));
+            var currentDate = DateTime.Parse(currentDateStr);
+            var expectedDate = DateTime.Parse(expectedDateStr);
 
             var actualDate = Statistic.GetSemesterStart(currentDate);
             Assert.Equal(expectedDate, actualDate);

--- a/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
@@ -6,7 +6,7 @@ namespace CoffeeCard.Tests.Unit.Models
 {
     public class SemesterStartTests
     {
-        [Theory(DisplayName = "When called in months Jan-Jun (inclusive), GetSemesterStart returns the last Monday of January")]
+        [Theory(DisplayName = "GetSemesterStart returns the correct semester start date based on currentDate")]
         [InlineData("2022/01/31", "2022/01/31")]
         [InlineData("2023/01/31", "2023/01/30")]
         [InlineData("2024/05/12", "2024/01/29")]
@@ -14,6 +14,8 @@ namespace CoffeeCard.Tests.Unit.Models
         [InlineData("2026/01/01", "2026/01/26")]
         [InlineData("2027/01/01", "2027/01/25")]
         [InlineData("2030/06/30", "2030/01/28")]
+        [InlineData("2000/07/01", "2000/07/01")]
+        [InlineData("2020/12/31", "2020/07/01")]
         public void TestSemesterStartGetsLastMondayOfJanuaryInSpring(string currentDateStr, string expectedDateStr)
         {
             var currentDate = DateTime.Parse(currentDateStr);

--- a/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Models/SemesterStartTests.cs
@@ -1,0 +1,29 @@
+﻿using CoffeeCard.WebApi.Models;
+using System;
+using Xunit;
+
+namespace CoffeeCard.Tests.Unit.Models
+{
+    public class SemesterStartTests
+    {
+        [Theory(DisplayName = "When called in months Jan-Jun (inclusive), GetSemesterStart returns the last Monday of January")]
+        [InlineData("2022/01/31", "2022/01/31")]
+        [InlineData("2023/01/31", "2023/01/30")]
+        [InlineData("2024/05/12", "2024/01/29")]
+        [InlineData("2025/06/24", "2025/01/27")]
+        [InlineData("2026/01/01", "2026/01/26")]
+        [InlineData("2027/01/01", "2027/01/25")]
+        [InlineData("2030/06/30", "2030/01/28")]
+        public void TestSemesterStartGetsLastMondayOfJanuaryInSpring(string currentDateStr, string expectedDateStr)
+        {
+            var cd = currentDateStr.Split('/');
+            var ed = expectedDateStr.Split('/');
+
+            var currentDate = new DateTime(int.Parse(cd[0]), int.Parse(cd[1]), int.Parse(cd[2]));
+            var expectedDate = new DateTime(int.Parse(ed[0]), int.Parse(ed[1]), int.Parse(ed[2]));
+
+            var actualDate = Statistic.GetSemesterStart(currentDate);
+            Assert.Equal(expectedDate, actualDate);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard.WebApi/Models/Statistic.cs
+++ b/coffeecard/CoffeeCard.WebApi/Models/Statistic.cs
@@ -30,7 +30,7 @@ namespace CoffeeCard.WebApi.Models
 
             // Spring semester: Get last Monday of January.
             var lastDayOfJan = new DateTime(currentTime.Year, 1, 31);
-            int correctedLastDayOfWeek = (int)(lastDayOfJan.DayOfWeek + 6) % 7;
+            int correctedLastDayOfWeek = (int)(lastDayOfJan.DayOfWeek + 6) % 7; // Mon=0, Tue=1, ..., Sun=6
             return lastDayOfJan.AddDays(-correctedLastDayOfWeek);
         }
 

--- a/coffeecard/CoffeeCard.WebApi/Models/Statistic.cs
+++ b/coffeecard/CoffeeCard.WebApi/Models/Statistic.cs
@@ -23,6 +23,10 @@ namespace CoffeeCard.WebApi.Models
         [ForeignKey("User_Id")]
         public virtual User User { get; set; }
 
+        /// <summary>
+        /// Get the start of date of the semester.
+        /// When <paramref name="currentTime"/> is in July (Month 7) or greater, the semester start is July 1st or when earlier than July, the semester start is the date of the last Monday of January.
+        /// </summary>
         public static DateTime GetSemesterStart(DateTime currentTime)
         {
             // Autumn semester: Get first day of July.
@@ -34,6 +38,10 @@ namespace CoffeeCard.WebApi.Models
             return lastDayOfJan.AddDays(-correctedLastDayOfWeek);
         }
 
+        /// <summary>
+        /// Get the end of date of the semester.
+        /// When <paramref name="currentTime"/> is in July (Month 7) or greater, the semester start is December 23rd or when earlier than July, the semester start is June 30rd.
+        /// </summary>
         public static DateTime GetSemesterEnd(DateTime currentTime)
         {
             if (currentTime.Month < 7) return new DateTime(currentTime.Year, 6, 30);

--- a/coffeecard/CoffeeCard.WebApi/Models/Statistic.cs
+++ b/coffeecard/CoffeeCard.WebApi/Models/Statistic.cs
@@ -25,16 +25,13 @@ namespace CoffeeCard.WebApi.Models
 
         public static DateTime GetSemesterStart(DateTime currentTime)
         {
-            if (currentTime.Month < 7)
-            {
-                var jan1 = new DateTime(currentTime.Year, 1, 1);
-                var dayOffset = DayOfWeek.Monday - jan1.DayOfWeek;
-                var startDate = 29 - dayOffset;
+            // Autumn semester: Get first day of July.
+            if (currentTime.Month >= 7) return new DateTime(currentTime.Year, 7, 1);
 
-                return new DateTime(currentTime.Year, 1, startDate);
-            }
-
-            return new DateTime(currentTime.Year, 7, 1);
+            // Spring semester: Get last Monday of January.
+            var lastDayOfJan = new DateTime(currentTime.Year, 1, 31);
+            int correctedLastDayOfWeek = (int)(lastDayOfJan.DayOfWeek + 6) % 7;
+            return lastDayOfJan.AddDays(-correctedLastDayOfWeek);
         }
 
         public static DateTime GetSemesterEnd(DateTime currentTime)


### PR DESCRIPTION
Fix a bug that would attempt to return a DateTime with day > 31
Add guard clause for autumn semester case