### PR TITLE
Refactored the loginLimiter to receive the logout time in seconds

### DIFF
--- a/coffeecard/CoffeeCard.Common/Configuration/LoginLimiterSettings.cs
+++ b/coffeecard/CoffeeCard.Common/Configuration/LoginLimiterSettings.cs
@@ -10,7 +10,7 @@ namespace CoffeeCard.Common.Configuration
         [Required]
         public int MaximumLoginAttemptsWithinTimeOut { get; set; }
         [Required]
-        public int TimeOutPeriodInMinutes { get; set; }
+        public int TimeOutPeriodInSeconds { get; set; }
 
         public void Validate()
         {

--- a/coffeecard/CoffeeCard.Library/Services/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/AccountService.cs
@@ -72,7 +72,7 @@ namespace CoffeeCard.Library.Services
                         email,
                         _httpContextAccessor.HttpContext.Connection.RemoteIpAddress);
                     throw new ApiException(
-                        $"Amount of failed login attempts exceeds the allowed amount, please wait for {_loginLimiterSettings.TimeOutPeriodInMinutes} minutes before trying again",
+                        $"Amount of failed login attempts exceeds the allowed amount, please wait for {_loginLimiterSettings.TimeOutPeriodInSeconds / 60} minutes before trying again",
                         StatusCodes.Status429TooManyRequests);
                 }
 

--- a/coffeecard/CoffeeCard.Library/Services/LoginLimiter.cs
+++ b/coffeecard/CoffeeCard.Library/Services/LoginLimiter.cs
@@ -51,7 +51,7 @@ namespace CoffeeCard.Library.Services
         public bool LoginAllowed(User user)
         {
             var (firstFailedLogin, loginAttemptsMade) = UpdateAndGetLoginAttemptCount(user.Email);
-            var timeOutPeriod = new TimeSpan(0, _loginLimiterSettings.TimeOutPeriodInMinutes, 0);
+            var timeOutPeriod = new TimeSpan(0, 0, _loginLimiterSettings.TimeOutPeriodInSeconds);
             var timeSinceFirstFailedLogin = DateTime.UtcNow.Subtract(firstFailedLogin);
 
             var maximumLoginAttemptsWithinTimeOut = _loginLimiterSettings.MaximumLoginAttemptsWithinTimeOut;

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/AccountServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/AccountServiceTest.cs
@@ -38,7 +38,7 @@ namespace CoffeeCard.Tests.Unit.Services
             };
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 5
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 5
             };
 
             var expectedResult = false;
@@ -74,7 +74,7 @@ namespace CoffeeCard.Tests.Unit.Services
             };
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 5
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 5
             };
 
             var expectedResult = true;
@@ -126,7 +126,7 @@ namespace CoffeeCard.Tests.Unit.Services
             };
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 5
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 5
             };
 
             var claim = new Claim(ClaimTypes.Email, "test@email.dk");
@@ -185,7 +185,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 5
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 5
             };
 
             var userTokens = new List<Token>();
@@ -236,7 +236,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 5
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 5
             };
 
             var userTokens = new List<Token>();
@@ -288,7 +288,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = false, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 5
+                IsEnabled = false, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 5
             };
 
             var userTokens = new List<Token>();
@@ -339,7 +339,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInSeconds = 1
             };
 
             var userTokens = new List<Token>();
@@ -373,7 +373,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 // Assert
                 var expectedException =
                     new ApiException(
-                        $"Amount of failed login attempts exceeds the allowed amount, please wait for {loginLimiterSettings.TimeOutPeriodInMinutes} minutes before trying again",
+                        $"Amount of failed login attempts exceeds the allowed amount, please wait for {loginLimiterSettings.TimeOutPeriodInSeconds / 60} minutes before trying again",
                         429);
                 Assert.Equal(tooManyLoginsException.StatusCode, expectedException.StatusCode);
                 Assert.Equal(tooManyLoginsException.Message, expectedException.Message);
@@ -395,7 +395,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInSeconds = 1
             };
 
             var userTokens = new List<Token>();
@@ -442,7 +442,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInSeconds = 1
             };
 
             var userTokens = new List<Token>();
@@ -489,7 +489,7 @@ namespace CoffeeCard.Tests.Unit.Services
                 {DeploymentUrl = "test", EnvironmentType = EnvironmentType.Test, MinAppVersion = "2.1.0"};
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInSeconds = 1
             };
 
             
@@ -536,7 +536,7 @@ namespace CoffeeCard.Tests.Unit.Services
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInSeconds = 1
             };
             var identitySettings = new IdentitySettings
             {
@@ -574,7 +574,7 @@ namespace CoffeeCard.Tests.Unit.Services
             var httpContextAccessor = new Mock<IHttpContextAccessor>();
             var loginLimiterSettings = new LoginLimiterSettings
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 1, TimeOutPeriodInSeconds = 1
             };
             var identitySettings = new IdentitySettings
             {

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/LoginLimiterTests.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/LoginLimiterTests.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using CoffeeCard.Common.Configuration;
 using CoffeeCard.Library.Services;
@@ -16,7 +16,7 @@ namespace CoffeeCard.Tests.Unit.Services
             // Arrange
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 1
             };
             var user = new User
             {
@@ -38,7 +38,7 @@ namespace CoffeeCard.Tests.Unit.Services
             loginLimiter.LoginAllowed(user);
             
             var lockedOutActual = loginLimiter.LoginAllowed(user); //Checks that you are actually locked after the initial attempts
-            await Task.Delay(61000);
+            await Task.Delay(1100);
             var loginAllowedAgainActual = loginLimiter.LoginAllowed(user); //Checks that you are allowed to login again after the timeout period
             
             Assert.Equal(lockedOutExpected, lockedOutActual);
@@ -46,12 +46,12 @@ namespace CoffeeCard.Tests.Unit.Services
         }
         
         [Fact(DisplayName = "Login can lockout twice")]
-        public void LoginLockoutsTwice()
+        public async Task LoginLockoutsTwice()
         {
             // Arrange
             var loginLimiterSettings = new LoginLimiterSettings()
             {
-                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInMinutes = 1
+                IsEnabled = true, MaximumLoginAttemptsWithinTimeOut = 5, TimeOutPeriodInSeconds = 1
             };
             var user = new User
             {
@@ -62,24 +62,25 @@ namespace CoffeeCard.Tests.Unit.Services
             var loginLimiter = new LoginLimiter(loginLimiterSettings);
             
             // Act
+            var allowedLoginResults = new List<bool>();
             //Triggers the lockout by attempting login 5 times in a row
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
+            for (var i = 0; i < loginLimiterSettings.MaximumLoginAttemptsWithinTimeOut; i++)
+            {
+                allowedLoginResults.Add(loginLimiter.LoginAllowed(user));
+            }
             var actualFirstLockoutResult = loginLimiter.LoginAllowed(user); //Checks that you are actually locked after the first series of attempts
-            Thread.Sleep(60001); //Passes the lockout time 
+            await Task.Delay(1100); //Passes the lockout time
+
 
             //Triggers the lockout again by another 5 attempted logins in a row
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
-            loginLimiter.LoginAllowed(user);
+            for (var i = 0; i < loginLimiterSettings.MaximumLoginAttemptsWithinTimeOut; i++)
+            {
+                allowedLoginResults.Add(loginLimiter.LoginAllowed(user));
+            }
             
             var actualLogoutResult = loginLimiter.LoginAllowed(user); //Checks that you are actually locked after the second series of attempts
             
+            Assert.All(allowedLoginResults, Assert.True);
             Assert.False(actualFirstLockoutResult);
             Assert.False(actualLogoutResult);
         }

--- a/coffeecard/CoffeeCard.WebApi/appsettings.json
+++ b/coffeecard/CoffeeCard.WebApi/appsettings.json
@@ -35,7 +35,7 @@
   "LoginLimiterSettings": {
     "IsEnabled": true,
     "MaximumLoginAttemptsWithinTimeOut": "3",
-    "TimeOutPeriodInMinutes": "15"
+    "TimeOutPeriodInSeconds": "900"
   },
   "Serilog": {
     "Using": [


### PR DESCRIPTION
The reason for this Pr is to increase the speed that our unit tests can complete at. This removes an artificial limit on them, where they could only complete after a minute had passed.

Do note, the appsettings.json used for production needs to be updated with the new value instead before deployment