### PR TITLE
Implemented get and update endpoints for AccountController v2 

### DIFF
--- a/coffeecard/CoffeeCard.Library/Services/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/AccountService.cs
@@ -264,18 +264,6 @@ namespace CoffeeCard.Library.Services
       return true;
     }
 
-    public async Task RequestAnonymization(User user)
-    {
-      var claims = new[]
-      {
-                new Claim(ClaimTypes.Email, user.Email), new Claim(ClaimTypes.Name, user.Name),
-                new Claim(ClaimTypes.Role, "verification_token")
-            };
-      var verificationToken = _tokenService.GenerateToken(claims);
-
-      await _emailService.SendVerificationEmailForDeleteAccount(user, verificationToken);
-    }
-
     public async Task AnonymizeAccountAsync(string token)
     {
       Log.Information("Trying to verify deletion with token: {token}", token);
@@ -284,11 +272,6 @@ namespace CoffeeCard.Library.Services
       var user = GetAccountByEmail(email);
 
       await AnonymizeUser(user);
-    }
-
-    public Task<bool> EmailExists(string email)
-    {
-      return _context.Users.AnyAsync(x => x.Email == email);
     }
 
     private async Task AnonymizeUser(User user)

--- a/coffeecard/CoffeeCard.Library/Services/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/AccountService.cs
@@ -264,16 +264,6 @@ namespace CoffeeCard.Library.Services
       return true;
     }
 
-    public async Task AnonymizeAccountAsync(string token)
-    {
-      Log.Information("Trying to verify deletion with token: {token}", token);
-
-      var email = _tokenService.ValidateVerificationTokenAndGetEmail(token);
-      var user = GetAccountByEmail(email);
-
-      await AnonymizeUser(user);
-    }
-
     private async Task AnonymizeUser(User user)
     {
       user.Email = string.Empty;

--- a/coffeecard/CoffeeCard.Library/Services/IAccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/IAccountService.cs
@@ -21,6 +21,5 @@ namespace CoffeeCard.Library.Services
         void UpdateExperience(int userId, int exp);
         Task ForgotPasswordAsync(string email);
         Task<bool> RecoverUserAsync(string token, string newPassword);
-        Task AnonymizeAccountAsync(string token);
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/IAccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/IAccountService.cs
@@ -21,8 +21,6 @@ namespace CoffeeCard.Library.Services
         void UpdateExperience(int userId, int exp);
         Task ForgotPasswordAsync(string email);
         Task<bool> RecoverUserAsync(string token, string newPassword);
-        Task RequestAnonymization(User user);
         Task AnonymizeAccountAsync(string token);
-        Task<bool> EmailExists(string email);
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using CoffeeCard.Common.Configuration;
+using CoffeeCard.Common.Errors;
+using CoffeeCard.Library.Persistence;
+using CoffeeCard.Models.DataTransferObjects.v2.Programme;
+using CoffeeCard.Models.DataTransferObjects.v2.User;
+using CoffeeCard.Models.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace CoffeeCard.Library.Services.v2
+{
+    public class AccountService : IAccountService
+    {
+        private readonly EnvironmentSettings _environmentSettings;
+        private readonly CoffeeCardContext _context;
+        private readonly IEmailService _emailService;
+        private readonly IHashService _hashService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ITokenService _tokenService;
+
+        public AccountService(CoffeeCardContext context, EnvironmentSettings environmentSettings,
+        ITokenService tokenService,
+            IEmailService emailService, IHashService hashService, IHttpContextAccessor httpContextAccessor,
+            ILoginLimiter loginLimiter, LoginLimiterSettings loginLimiterSettings)
+        {
+            _context = context;
+            _environmentSettings = environmentSettings;
+            _tokenService = tokenService;
+            _emailService = emailService;
+            _hashService = hashService;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<UserResponse> RegisterAccountAsync(string name, string email, string password, int programme = 1)
+        {
+            Log.Information("Trying to register new user. Name: {name} Email: {email}", name, email);
+
+            if (_context.Users.Any(x => x.Email == email))
+            {
+                Log.Information("Could not register user Name: {name}. Email:{email} already exists", name, email);
+                throw new ApiException($"The email {email} is already being used by another user",
+                StatusCodes.Status409Conflict);
+            }
+
+            var salt = _hashService.GenerateSalt();
+            var hashedPassword = _hashService.Hash(password + salt);
+
+            var chosenProgramme = _context.Programmes.FirstOrDefault(x => x.Id == programme);
+            if (chosenProgramme == null)
+                throw new ApiException($"No programme found with the id: {programme}", StatusCodes.Status400BadRequest);
+
+            var user = new User
+            {
+                Name = EscapeName(name),
+                Email = email,
+                Password = hashedPassword,
+                Salt = salt,
+                Programme = chosenProgramme,
+                UserGroup = UserGroup.Customer
+            };
+
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Email, user.Email), new Claim(ClaimTypes.Name, user.Name),
+                new Claim(ClaimTypes.Role, "verification_token")
+            };
+            var verificationToken = _tokenService.GenerateToken(claims);
+
+            await _emailService.SendRegistrationVerificationEmailAsync(user, verificationToken);
+
+            return new UserResponse()
+            {
+                Id = user.Id,
+                Name = user.Name,
+                Email = user.Email,
+                PrivacyActivated = user.PrivacyActivated,
+                Programme = new ProgrammeResponse()
+                {
+                    Id = user.Programme.Id,
+                    ShortName = user.Programme.ShortName,
+                    FullName = user.Programme.FullName
+                },
+                RankAllTime = 0, //All ranks are zero due to newly created user
+                RankMonth = 0,
+                RankSemester = 0,
+            };
+        }
+
+        public async Task<bool> VerifyRegistration(string token)
+        {
+            Log.Information("Trying to verify registration with token: {token}", token);
+
+            var email = _tokenService.ValidateVerificationTokenAndGetEmail(token);
+            var user = GetAccountByEmail(email);
+
+            user.IsVerified = true;
+            return await _context.SaveChangesAsync() > 0;
+        }
+
+        public User UpdateAccount(IEnumerable<Claim> claims, UpdateUserRequest userDto)
+        {
+            var user = GetAccountByClaims(claims);
+
+            if (userDto.Email != null)
+            {
+                if (_context.Users.Any(x => x.Email == userDto.Email))
+                    throw new ApiException($"The email {userDto.Email} is already in use!", 400);
+                Log.Information($"Changing email of user from {user.Email} to {userDto.Email}");
+                user.Email = userDto.Email;
+            }
+
+            if (userDto.Name != null)
+            {
+                Log.Information($"Changing name of user from {user.Name} to {EscapeName(userDto.Name)}");
+                user.Name = EscapeName(userDto.Name);
+            }
+
+            if (userDto.PrivacyActivated != null)
+            {
+                Log.Information(
+                    $"Changing privacy of user from {user.PrivacyActivated} to {(bool)userDto.PrivacyActivated}");
+                user.PrivacyActivated = (bool)userDto.PrivacyActivated;
+            }
+
+            if (userDto.ProgrammeId != null)
+            {
+                var programme = _context.Programmes.FirstOrDefault(x => x.Id == userDto.ProgrammeId);
+                if (programme == null)
+                    throw new ApiException($"No programme with id {userDto.ProgrammeId} exists!", 400);
+                Log.Information($"Changing programme of user from {user.Programme.Id} to {programme.Id}");
+                user.Programme = programme;
+            }
+
+            if (userDto.Password != null)
+            {
+                var salt = _hashService.GenerateSalt();
+                var hashedPassword = _hashService.Hash(userDto.Password + salt);
+                user.Salt = salt;
+                user.Password = hashedPassword;
+                Log.Information("User changed password");
+            }
+
+            _context.SaveChanges();
+            return user;
+        }
+
+        public User GetAccountByClaims(IEnumerable<Claim> claims)
+        {
+            var emailClaim = claims.FirstOrDefault(x => x.Type == ClaimTypes.Email);
+            if (emailClaim == null) throw new ApiException("The token is invalid!", 401);
+
+            var user = GetAccountByEmail(emailClaim.Value);
+            if (user == null) throw new ApiException("The user could not be found", 400);
+
+            return user;
+        }
+
+        public void UpdateExperience(int userId, int exp)
+        {
+            var user = _context.Users.FirstOrDefault(x => x.Id == userId);
+
+            if (user == null) throw new ApiException("Could not update user");
+
+            user.Experience += exp;
+
+            _context.SaveChanges();
+        }
+
+        public async Task ForgotPasswordAsync(string email)
+        {
+            var user = GetAccountWithTokensByEmail(email);
+            if (user == null)
+                throw new ApiException($"The user could not be found {email}", StatusCodes.Status404NotFound);
+
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Email, user.Email), new Claim(ClaimTypes.Name, user.Name),
+                new Claim(ClaimTypes.Role, "verification_token")
+            };
+            var verificationToken = _tokenService.GenerateToken(claims);
+            user.Tokens.Add(new Token(verificationToken));
+            _context.SaveChanges();
+            await _emailService.SendVerificationEmailForLostPwAsync(user, verificationToken);
+        }
+
+        public async Task<bool> RecoverUserAsync(string token, string newPassword)
+        {
+            var tokenObj = _tokenService.ReadToken(token);
+            if (tokenObj == null) return false;
+
+            Log.Information($"User tried to recover with token {token}");
+            if (!await _tokenService.ValidateTokenIsUnusedAsync(token)) return false;
+
+            var user = GetAccountByClaims(tokenObj.Claims);
+            if (user == null) return false;
+
+            Log.Information($"{user.Email} tried to recover user");
+            var sha256Pw = _hashService.Hash(newPassword);
+            var salt = _hashService.GenerateSalt();
+            var hashedPassword = _hashService.Hash(sha256Pw + salt);
+            user.Salt = salt;
+            user.Password = hashedPassword;
+            user.IsVerified = true;
+            user.Tokens.Clear();
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        public async Task RequestAnonymization(User user)
+        {
+            var claims = new[]
+            {
+                new Claim(ClaimTypes.Email, user.Email), new Claim(ClaimTypes.Name, user.Name),
+                new Claim(ClaimTypes.Role, "verification_token")
+            };
+            var verificationToken = _tokenService.GenerateToken(claims);
+
+            await _emailService.SendVerificationEmailForDeleteAccount(user, verificationToken);
+        }
+
+        public async Task AnonymizeAccountAsync(string token)
+        {
+            Log.Information("Trying to verify deletion with token: {token}", token);
+
+            var email = _tokenService.ValidateVerificationTokenAndGetEmail(token);
+            var user = GetAccountByEmail(email);
+
+            await AnonymizeUser(user);
+        }
+
+        public Task<bool> EmailExists(string email)
+        {
+            return _context.Users.AnyAsync(x => x.Email == email);
+        }
+
+        private async Task AnonymizeUser(User user)
+        {
+            user.Email = string.Empty;
+            user.Name = string.Empty;
+            user.Password = string.Empty;
+            user.Salt = string.Empty;
+            user.DateUpdated = DateTime.Now;
+            user.PrivacyActivated = true;
+            user.UserState = UserState.Deleted;
+            await _context.SaveChangesAsync();
+        }
+
+        private User GetAccountByEmail(string email)
+        {
+            var user = _context.Users
+                .Include(x => x.Programme)
+                //.Include(x => x.Statistics)
+                .FirstOrDefault(x => x.Email == email);
+            if (user == null) throw new ApiException("No user found with the given email", 401);
+
+            return user;
+        }
+
+        private User GetAccountWithTokensByEmail(string email)
+        {
+            var user = _context.Users.Include(x => x.Tokens).FirstOrDefault(x => x.Email == email);
+
+            if (user == null) throw new ApiException("No user found with the given email", 401);
+            return user;
+        }
+
+        private static string EscapeName(string name)
+        {
+            return name.Trim('<', '>', '{', '}');
+        }
+
+        private void ValidateVersion(string version)
+        {
+            var regex = new Regex(@"(\d+.)(\d+.)(\d+)");
+            var match = regex.Match(version);
+
+            if (!match.Success || match.Groups.Count != 4)
+                throw new ApiException("Malformed version number", 400);
+
+            var major = int.Parse(match.Groups[1].Value.TrimEnd('.'));
+            var minor = int.Parse(match.Groups[2].Value.TrimEnd('.'));
+
+            var requiredMatch = regex.Match(_environmentSettings.MinAppVersion);
+            var requiredMajor = int.Parse(requiredMatch.Groups[1].Value.TrimEnd('.'));
+            var requiredMinor = int.Parse(requiredMatch.Groups[2].Value.TrimEnd('.'));
+
+            if (requiredMajor > major || requiredMinor > minor)
+                throw new ApiException("Your App is out of date - please update!", 409);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
@@ -15,11 +15,7 @@ namespace CoffeeCard.Library.Services.v2
         /// </summary>
         /// <param name="programme">Programme Id of ITU Study programme.
         Task<UserResponse> RegisterAccountAsync(string name, string email, string password, int programme);
-        Task<bool> VerifyRegistration(string token);
         User UpdateAccount(IEnumerable<Claim> claims, UpdateUserRequest userDto);
-        void UpdateExperience(int userId, int exp);
-        Task ForgotPasswordAsync(string email);
-        Task<bool> RecoverUserAsync(string token, string newPassword);
         Task RequestAnonymization(User user);
         Task AnonymizeAccountAsync(string token);
         Task<bool> EmailExists(string email);

--- a/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using CoffeeCard.Models.DataTransferObjects.v2.User;
+using CoffeeCard.Models.Entities;
+
+namespace CoffeeCard.Library.Services.v2
+{
+    public interface IAccountService
+    {
+        User GetAccountByClaims(IEnumerable<Claim> claims);
+
+        /// <summary>
+        /// Register an account. Sends out an verification email to provided email
+        /// </summary>
+        /// <param name="programme">Programme Id of ITU Study programme.
+        Task<UserResponse> RegisterAccountAsync(string name, string email, string password, int programme);
+        Task<bool> VerifyRegistration(string token);
+        User UpdateAccount(IEnumerable<Claim> claims, UpdateUserRequest userDto);
+        void UpdateExperience(int userId, int exp);
+        Task ForgotPasswordAsync(string email);
+        Task<bool> RecoverUserAsync(string token, string newPassword);
+        Task RequestAnonymization(User user);
+        Task AnonymizeAccountAsync(string token);
+        Task<bool> EmailExists(string email);
+    }
+}

--- a/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
@@ -8,16 +8,44 @@ namespace CoffeeCard.Library.Services.v2
 {
     public interface IAccountService
     {
-        User GetAccountByClaims(IEnumerable<Claim> claims);
+        /// <summary>
+        /// Retrives a users account by receiving the claims from a jwt token
+        /// </summary>
+        /// <param name="claims">A list of all claims from a jwt token
+        Task<User> GetAccountByClaimsAsync(IEnumerable<Claim> claims);
 
         /// <summary>
         /// Register an account. Sends out an verification email to provided email
         /// </summary>
+        /// <param name="name"> Name of the user
+        /// <param name="email"> The email address of the account to be created 
+        /// <param name="password"> Desired password for the account
         /// <param name="programme">Programme Id of ITU Study programme.
-        Task<UserResponse> RegisterAccountAsync(string name, string email, string password, int programme);
-        User UpdateAccount(IEnumerable<Claim> claims, UpdateUserRequest userDto);
-        Task RequestAnonymization(User user);
+        Task<User> RegisterAccountAsync(string name, string email, string password, int programme);
+
+        /// <summary>
+        /// Updates an account with the non-null properties of the updateUserRequest
+        /// </summary>
+        /// <param name="user"> The user entity representing an account
+        /// <param name="updateUserRequest"> The request to update the user, containing several nullable properties 
+        Task<User> UpdateAccountAsync(User user, UpdateUserRequest updateUserRequest);
+
+        /// <summary>
+        /// Generates a token used for account deletion, and passes it to the email service
+        /// </summary>
+        /// <param name="user"> The user entity representing an account
+        Task RequestAnonymizationAsync(User user);
+
+        /// <summary>
+        /// Anonymizes a users account by removing all identifyable information, effectively deleting it
+        /// </summary>
+        /// <param name="token"> The jwt token giving permission to delete the account
         Task AnonymizeAccountAsync(string token);
-        Task<bool> EmailExists(string email);
+
+        /// <summary>
+        /// Checks if an account already exists with the given email
+        /// </summary>
+        /// <param name="email"> An email address, represented as a string
+        Task<bool> EmailExistsAsync(string email);
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/v2/ILeaderboardService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/ILeaderboardService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using CoffeeCard.Models.DataTransferObjects.v2.Leaderboard;
 using CoffeeCard.Models.Entities;
@@ -22,5 +22,8 @@ namespace CoffeeCard.Library.Services.v2
         /// <param name="preset">Preset to filter</param>
         /// <returns>Leaderboard entry for user</returns>
         Task<LeaderboardEntry> GetLeaderboardEntry(User user, LeaderboardPreset preset);
+
+        //Todo add desciption
+        Task<(int Total, int Semester, int Month)> GetLeaderboardPlacement(User user);
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/v2/ILeaderboardService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/ILeaderboardService.cs
@@ -23,7 +23,10 @@ namespace CoffeeCard.Library.Services.v2
         /// <returns>Leaderboard entry for user</returns>
         Task<LeaderboardEntry> GetLeaderboardEntry(User user, LeaderboardPreset preset);
 
-        //Todo add desciption
+        /// <summary>
+        /// Retruns a triple representing the users current placement on the leaderboard
+        /// </summary>
+        /// <param name="user">User</param>
         Task<(int Total, int Semester, int Month)> GetLeaderboardPlacement(User user);
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/v2/LeaderboardService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/LeaderboardService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CoffeeCard.Library.Persistence;
@@ -74,6 +74,25 @@ namespace CoffeeCard.Library.Services.v2
                 Score = swipeCount
             };
         }
+
+
+        public async Task<(int Total, int Semester, int Month)> GetLeaderboardPlacement(User user)
+        {
+            var leaderBoardPlacement = (Total: 0, Semester: 0, Month: 0);
+
+            var totalSwipe = await GetLeaderboardEntry(user, LeaderboardPreset.Total);
+
+            var semesterSwipe = await GetLeaderboardEntry(user, LeaderboardPreset.Semester);
+
+            var monthSwipe = await GetLeaderboardEntry(user, LeaderboardPreset.Month);
+
+            leaderBoardPlacement.Total = totalSwipe.Rank;
+            leaderBoardPlacement.Semester = semesterSwipe.Rank;
+            leaderBoardPlacement.Month = monthSwipe.Rank;
+
+            return leaderBoardPlacement;
+        }
+        
 
         private bool IsSwipeValid(Statistic s)
         {

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Programme/ProgrammeDto.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Programme/ProgrammeDto.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CoffeeCard.Models.DataTransferObjects.v2.Programme
+{
+    /// <summary>
+    /// Represents a study programme
+    /// </summary>
+    /// <example>
+    /// {
+    ///     "id": 1,
+    ///     "shortName": "SWU",
+    ///     "fullName": "Software Development"
+    /// }
+    /// </example>
+    public class ProgrammeResponse
+    {
+        /// <summary>
+        /// Id of study programme
+        /// </summary>
+        /// <value>Study Programme Id</value>
+        /// <example>1</example>
+        [Required]
+        public int Id { get; set; }
+        
+        /// <summary>
+        /// Short name of study programme
+        /// </summary>
+        /// <example>SWU</example>
+        [Required]
+        public string ShortName { get; set; }
+        
+        /// <summary>
+        /// Full name of study programme
+        /// </summary>
+        /// <value>Full name</value>
+        /// <example>Software development</example>
+        [Required]
+        public string FullName { get; set; }
+    }
+}

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/RegisterAccountRequest.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/RegisterAccountRequest.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
-namespace CoffeeCard.Models.DataTransferObjects.V2.User
+namespace CoffeeCard.Models.DataTransferObjects.v2.User
 {
     /// <summary>
     /// Register a new user

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/UpdateUserRequest.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/UpdateUserRequest.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace CoffeeCard.Models.DataTransferObjects.v2.User
+{
+    /// <summary>
+    /// Update User information request object. All properties are optional as the server only updates the values of the properties which are present
+    /// </summary>
+    /// <example>
+    /// {
+    ///     "name": "John Doe",
+    ///     "email": "john@doe.com",
+    ///     "privacyActivated": true,
+    ///     "programmeId": 1,
+    ///     "password": "[no example provided]"
+    /// }
+    /// </example>
+    public class UpdateUserRequest
+    {
+        /// <summary>
+        /// Full Name of user
+        /// </summary>
+        /// <value>Full Name</value>
+        /// <example>John Doe</example>
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// Email of user
+        /// </summary>
+        /// <value>Email</value>
+        /// <example>john@doe.com</example>
+        [EmailAddress]
+        public string Email { get; set; }
+        
+        /// <summary>
+        /// Privacy Activated
+        /// </summary>
+        /// <value>Privacy Activated</value>
+        /// <example>true</example>
+        public bool? PrivacyActivated { get; set; }
+        
+        /// <summary>
+        /// Study Programme Id of user
+        /// </summary>
+        /// <value>Study Programme Id</value>
+        /// <example>1</example>
+        public int? ProgrammeId { get; set; }
+        
+        /// <summary>
+        /// Pin Code as first UTF8 encoded, then SHA256 hashed, and then Base64 encoded string
+        /// </summary>
+        /// <value>Pin code</value>
+        /// <example>[no example provided]</example>
+        public string Password { get; set; }
+    }
+}

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/UserResponse.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/UserResponse.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel.DataAnnotations;
+using CoffeeCard.Models.DataTransferObjects.v2.Programme;
+
+namespace CoffeeCard.Models.DataTransferObjects.v2.User
+{
+    /// <summary>
+    /// User information
+    /// </summary>
+    /// <example>
+    /// {
+    ///     "id": 123,
+    ///     "name": "John Doe",
+    ///     "email": "john@doe.com",
+    ///     "privacyActivated": true,
+    ///     "programme": 1,
+    ///     "rankAllTime": 15,
+    ///     "rankSemester": 4,
+    ///     "rankMonth": 5
+    /// }
+    /// </example>
+    public class UserResponse
+    {
+        /// <summary>
+        /// User Id
+        /// </summary>
+        /// <value>User Id</value>
+        /// <example>123</example>
+        [Required]
+        public int Id { get; set; }
+        
+        /// <summary>
+        /// Full Name of user
+        /// </summary>
+        /// <value>Full Name</value>
+        /// <example>John Doe</example>
+        [Required]
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// Email of user
+        /// </summary>
+        /// <value>Email</value>
+        /// <example>john@doe.com</example>
+        [Required]
+        public string Email { get; set; }
+        
+        /// <summary>
+        /// Privacy Activated
+        /// </summary>
+        /// <value>Privacy Activated</value>
+        /// <example>true</example>
+        [Required]
+        public bool PrivacyActivated { get; set; }
+        
+        /// <summary>
+        /// Study Programme Id of user
+        /// </summary>
+        /// <value>Study Programme Id</value>
+        /// <example>1</example>
+        [Required]
+        public ProgrammeResponse Programme { get; set; }
+        
+        /// <summary>
+        /// User's Rank all time
+        /// </summary>
+        /// <value>All time rank</value>
+        /// <example>15</example>
+        [Required]
+        public int RankAllTime { get; set; }
+        
+        /// <summary>
+        /// User's rank current semester
+        /// </summary>
+        /// <value>Semester rank</value>
+        /// <example>4</example>
+        [Required]
+        public int RankSemester { get; set; }
+        
+        /// <summary>
+        /// User's rank current month
+        /// </summary>
+        /// <value>Month rank</value>
+        /// <example>5</example>
+        [Required]
+        public int RankMonth { get; set; }
+    }
+}

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/v2/AccountServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/v2/AccountServiceTest.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using CoffeeCard.Common.Configuration;
+using CoffeeCard.Common.Errors;
+using CoffeeCard.Library.Persistence;
+using CoffeeCard.Library.Services;
+using CoffeeCard.Library.Services.v2;
+using CoffeeCard.Library.Utils;
+using CoffeeCard.Models.DataTransferObjects.v2.Programme;
+using CoffeeCard.Models.DataTransferObjects.v2.User;
+using CoffeeCard.Models.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Xunit;
+
+namespace CoffeeCard.Tests.Unit.Services.v2
+{
+    public class AccountServiceTest
+    {
+        private CoffeeCardContext CreateTestCoffeeCardContextWithName(String name)
+        {
+            var builder = new DbContextOptionsBuilder<CoffeeCardContext>()
+                .UseInMemoryDatabase(name);
+
+            var databaseSettings = new DatabaseSettings
+            {
+                SchemaName = "test"
+            };
+            var environmentSettings = new EnvironmentSettings()
+            {
+                EnvironmentType = EnvironmentType.Test
+            };
+
+            return new CoffeeCardContext(builder.Options, databaseSettings, environmentSettings);
+        }
+
+        [Fact(DisplayName = "GetAccountByClaims returns user, given claim with email")]
+        public async Task GetAccountByClaimsReturnsUserClaimWithEmail()
+        {
+            // Arrange
+            var claims = new List<Claim>() { new Claim(ClaimTypes.Email, "test@test.test") };
+            var expected = new User() { Email = "test@test.test" };
+            User result;
+
+            using var context = CreateTestCoffeeCardContextWithName(nameof(GetAccountByClaimsReturnsUserClaimWithEmail));
+            context.Users.Add(expected);
+            await context.SaveChangesAsync();
+            // Act
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+            result = await accountService.GetAccountByClaimsAsync(claims);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+
+        [Theory(DisplayName = "GetAccountByClaims throws ApieEception, given invalid claim")]
+        [MemberData(nameof(ClaimGenerator))]
+        public async Task GetAccountByClaimsThrowsApiExceptionGivenInvalidClaim(IEnumerable<Claim> claims)
+        {
+            // Arrange
+            var validUser = new User() { Email = "test@test.test" };
+
+            using var context = CreateTestCoffeeCardContextWithName(nameof(GetAccountByClaimsThrowsApiExceptionGivenInvalidClaim) + claims.ToString());
+            context.Users.Add(validUser);
+            await context.SaveChangesAsync();
+            // Act
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+
+            // Assert
+            await Assert.ThrowsAsync<ApiException>(async () => await accountService.GetAccountByClaimsAsync(claims));
+        }
+
+        [Theory(DisplayName = "RegisterAccount returns user on valid input")]
+        [InlineData("test", "test@test.test", "testPass", 1)]
+        [InlineData("test1", "test", "1", 2)]
+        [InlineData("test2", "test@test", "440", 3)]
+        [InlineData("test3", "test+1@test.test", "Pass", 4)]
+        public async Task RegisterAccountReturnsUserOnValidInput(String name, String email, string password, int programmeId)
+        {
+            // Arrange
+            var programme = new Programme()
+            {
+                Id = programmeId,
+                FullName = "test",
+                ShortName = "t",
+                Users = new List<User>()
+            };
+            var expectedPass = "HashedPassword";
+            var expected = new User()
+            {
+                Name = name,
+                Email = email,
+                Password = expectedPass,
+                PrivacyActivated = false,
+                Programme = programme
+            };
+            User result;
+
+            // Using same context across all valid users to test creation of multiple users
+            using var context = CreateTestCoffeeCardContextWithName(nameof(RegisterAccountReturnsUserOnValidInput));
+            var emailServiceMock = new Mock<IEmailService>();
+            emailServiceMock.Setup(e => e.SendRegistrationVerificationEmailAsync(It.IsAny<User>(), It.IsAny<String>())).Returns(Task.CompletedTask);
+            var emailService = emailServiceMock.Object;
+
+            var hashServiceMock = new Mock<IHashService>();
+            hashServiceMock.Setup(h => h.Hash(It.IsAny<String>())).Returns(expectedPass);
+            var hashService = hashServiceMock.Object;
+
+            context.Programmes.Add(programme);
+            await context.SaveChangesAsync();
+            // Act
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
+                emailService, hashService);
+            result = await accountService.RegisterAccountAsync(name, email, password, programmeId);
+
+            // Assert
+            // Comparing specific properties instead of object since DateCreated would not be equals
+            Assert.Equal(expected.Name, result.Name);
+            Assert.Equal(expected.Programme.Id, result.Programme.Id);
+            Assert.Equal(expected.Email, result.Email);
+            Assert.Equal(expected.Password, result.Password);
+        }
+
+        [Fact(DisplayName = "RegisterAccount throws ApiException with status 409 on existing email")]
+        public async Task RegisterAccountThrowsApiExceptionWithStatus409OnExistingEmail()
+        {
+            // Arrange
+            var programme = new Programme() { Id = 1, FullName = "test", ShortName = "t", SortPriority = 1, Users = new List<User>() };
+            var email = "test@test.dk";
+
+            using var context = CreateTestCoffeeCardContextWithName(nameof(RegisterAccountThrowsApiExceptionWithStatus409OnExistingEmail));
+            context.Programmes.Add(programme);
+            await context.SaveChangesAsync();
+            // Act
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+
+            // Assert
+            // Register the first user
+            await accountService.RegisterAccountAsync("name", email, "pass", 1);
+            // Try to register user with the sme email as before
+            var exception = await Assert.ThrowsAsync<ApiException>(
+                async () => await accountService.RegisterAccountAsync("name", email, "pass", 1));
+            Assert.Equal(StatusCodes.Status409Conflict, exception.StatusCode);
+        }
+
+        [Fact(DisplayName = "RegisterAccount throws ApiException with status 400 when given invalid programmeId")]
+        public async Task RegisterAccountThrowsApiExceptionWithStatus400WhenGivenInvalidProgrammeId()
+        {
+            // Arrange
+            using var context = CreateTestCoffeeCardContextWithName(nameof(RegisterAccountThrowsApiExceptionWithStatus400WhenGivenInvalidProgrammeId));
+            // Act
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<ApiException>(
+                async () => await accountService.RegisterAccountAsync("name", "email", "pass", 1));
+            Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        }
+
+        [Fact(DisplayName = "RegisterAccount sends verification email only valid input")]
+        public async Task RegisterAccountSendsVerificationEmailOnlyValidInput()
+        {
+            // Arrange
+            var programme = new Programme()
+            {
+                Id = 1,
+                FullName = "test",
+                ShortName = "t",
+                Users = new List<User>()
+            };
+            var expectedPass = "HashedPassword";
+            var expected = new User()
+            {
+                Name = "name",
+                Email = "email",
+                Password = expectedPass,
+                PrivacyActivated = false,
+                Programme = programme
+            };
+            User result;
+
+            // Using same context across all valid users to test creation of multiple users
+            using var context = CreateTestCoffeeCardContextWithName(nameof(RegisterAccountSendsVerificationEmailOnlyValidInput));
+            var emailServiceMock = new Mock<IEmailService>();
+            emailServiceMock.Setup(e => e.SendRegistrationVerificationEmailAsync(It.IsAny<User>(), It.IsAny<String>())).Returns(Task.CompletedTask);
+            var emailService = emailServiceMock.Object;
+
+            var hashServiceMock = new Mock<IHashService>();
+            hashServiceMock.Setup(h => h.Hash(It.IsAny<String>())).Returns(expectedPass);
+            var hashService = hashServiceMock.Object;
+
+            context.Programmes.Add(programme);
+            await context.SaveChangesAsync();
+            // Act
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
+                emailService, hashService);
+            result = await accountService.RegisterAccountAsync("name", "email", "password", 1);
+
+            // Assert
+            // Verify an email would have been send for the first registration
+            emailServiceMock.Verify(e => e.SendRegistrationVerificationEmailAsync(It.IsAny<User>(), It.IsAny<String>()), Times.Exactly(1));
+
+            await Assert.ThrowsAsync<ApiException>(
+                async () => await accountService.RegisterAccountAsync("name", "email", "pass", 1));
+            // Verify no email was send for the second, failed registration
+            emailServiceMock.Verify(e => e.SendRegistrationVerificationEmailAsync(It.IsAny<User>(), It.IsAny<String>()), Times.Exactly(1));
+        }
+
+        public static IEnumerable<object[]> ClaimGenerator()
+        {
+            yield return new object[] {
+                new List<Claim> // Good token, assuming user can be found in database 
+                {
+                    new Claim(ClaimTypes.Email, "userNotInDb@test.test"),
+                    new Claim(ClaimTypes.Role, "")
+                }
+            };
+            yield return new object[] {
+                new List<Claim> // No email claim
+                {
+                    new Claim(ClaimTypes.Role, "verification_token")
+                }
+            };
+        }
+    }
+}

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/AccountController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/AccountController.cs
@@ -70,7 +70,7 @@ namespace CoffeeCard.WebApi.Controllers.v2
         {
             var user = await _claimsUtilities.ValidateAndReturnUserFromClaimAsync(User.Claims);
 
-            await _accountService.RequestAnonymization(user);
+            await _accountService.RequestAnonymizationAsync(user);
             return NoContent();
         }
 
@@ -86,7 +86,7 @@ namespace CoffeeCard.WebApi.Controllers.v2
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
         public async Task<ActionResult<UserResponse>> Get()
         {
-            var user = _accountService.GetAccountByClaims(User.Claims);
+            var user = await _accountService.GetAccountByClaimsAsync(User.Claims);
 
             return Ok(await UserWithRanking(user));
         }
@@ -105,9 +105,10 @@ namespace CoffeeCard.WebApi.Controllers.v2
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
         public async Task<ActionResult<UserResponse>> Update([FromBody] UpdateUserRequest updateUserRequest)
         {
-            var user = _accountService.UpdateAccount(User.Claims, updateUserRequest);
+            var user = await _accountService.GetAccountByClaimsAsync(User.Claims);
+            var updatedUser = await _accountService.UpdateAccountAsync(user, updateUserRequest);
 
-            return Ok(await UserWithRanking(user));
+            return Ok(await UserWithRanking(updatedUser));
         }
 
 
@@ -125,7 +126,7 @@ namespace CoffeeCard.WebApi.Controllers.v2
         [Route("email-exists")]
         public async Task<ActionResult<EmailExistsResponse>> EmailExists([FromBody] EmailExistsRequest request)
         {
-            var emailInUse = await _accountService.EmailExists(request.Email);
+            var emailInUse = await _accountService.EmailExistsAsync(request.Email);
             return Ok(new EmailExistsResponse()
             {
                 EmailExists = emailInUse

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/AccountController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/AccountController.cs
@@ -1,13 +1,14 @@
 using System.Threading.Tasks;
 using CoffeeCard.Common.Errors;
-using CoffeeCard.Library.Services;
 using CoffeeCard.Library.Utils;
 using CoffeeCard.Models.DataTransferObjects;
 using CoffeeCard.Models.DataTransferObjects.v2.User;
-using CoffeeCard.Models.DataTransferObjects.V2.User;
+using CoffeeCard.Models.DataTransferObjects.v2.Programme;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using CoffeeCard.Library.Services.v2;
+using CoffeeCard.Models.Entities;
 
 namespace CoffeeCard.WebApi.Controllers.v2
 {
@@ -22,14 +23,16 @@ namespace CoffeeCard.WebApi.Controllers.v2
     {
         private readonly IAccountService _accountService;
         private readonly ClaimsUtilities _claimsUtilities;
-        
+        private readonly ILeaderboardService _leaderboardService;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AccountController"/> class.
         /// </summary>
-        public AccountController(IAccountService accountService, ClaimsUtilities claimsUtilities)
+        public AccountController(IAccountService accountService, ClaimsUtilities claimsUtilities, ILeaderboardService leaderboardService)
         {
             _accountService = accountService;
             _claimsUtilities = claimsUtilities;
+            _leaderboardService = leaderboardService;
         }
 
         /// <summary>
@@ -66,11 +69,48 @@ namespace CoffeeCard.WebApi.Controllers.v2
         public async Task<ActionResult> Delete()
         {
             var user = await _claimsUtilities.ValidateAndReturnUserFromClaimAsync(User.Claims);
-            
+
             await _accountService.RequestAnonymization(user);
             return NoContent();
         }
-        
+
+
+        /// <summary>
+        /// Returns basic data about the account
+        /// </summary>
+        /// <returns>Account information</returns>
+        /// <response code="200">Successful request</response>
+        /// <response code="401">Invalid credentials</response>
+        [HttpGet]
+        [ProducesResponseType(typeof(UserResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<UserResponse>> Get()
+        {
+            var user = _accountService.GetAccountByClaims(User.Claims);
+
+            return Ok(await UserWithRanking(user));
+        }
+
+        /// <summary>
+        /// Updates the account and returns the updated values.
+        /// Only properties which are present in the <see cref="UpdateUserRequest"/> will be updated
+        /// </summary>
+        /// <param name="updateUserRequest">Update account information request. All properties are optional as the server only
+        /// updates the values of the properties which are present</param>
+        /// <returns>Account information</returns>
+        /// <response code="200">Successful request</response>
+        /// <response code="401">Invalid credentials</response>
+        [HttpPut]
+        [ProducesResponseType(typeof(UserResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
+        public async Task<ActionResult<UserResponse>> Update([FromBody] UpdateUserRequest updateUserRequest)
+        {
+            var user = _accountService.UpdateAccount(User.Claims, updateUserRequest);
+
+            return Ok(await UserWithRanking(user));
+        }
+
+
         /// <summary>
         /// Check if a given email is in use
         /// </summary>
@@ -90,6 +130,26 @@ namespace CoffeeCard.WebApi.Controllers.v2
             {
                 EmailExists = emailInUse
             });
+        }
+
+        private async Task<UserResponse> UserWithRanking(User user){
+            var leaderBoardPlacement = await _leaderboardService.GetLeaderboardPlacement(user);
+
+            return new UserResponse
+            {
+                RankAllTime = leaderBoardPlacement.Total,
+                RankMonth = leaderBoardPlacement.Month,
+                RankSemester = leaderBoardPlacement.Semester,
+                Name = user.Name,
+                Programme = new ProgrammeResponse()
+                {
+                    Id = user.Programme.Id,
+                    ShortName = user.Programme.ShortName,
+                    FullName = user.Programme.FullName
+                },
+                PrivacyActivated = user.PrivacyActivated,
+            };
+            
         }
     }
 }

--- a/coffeecard/CoffeeCard.WebApi/Pages/VerifyDelete.cshtml.cs
+++ b/coffeecard/CoffeeCard.WebApi/Pages/VerifyDelete.cshtml.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using CoffeeCard.Library.Services;
+using CoffeeCard.Library.Services.v2;
 using CoffeeCard.WebApi.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/coffeecard/CoffeeCard.WebApi/Startup.cs
+++ b/coffeecard/CoffeeCard.WebApi/Startup.cs
@@ -66,6 +66,7 @@ namespace CoffeeCard.WebApi
             services.AddTransient<ITokenService, TokenService>();
             services.AddSingleton<ILoginLimiter, LoginLimiter>();
             services.AddScoped<IAccountService, AccountService>();
+            services.AddScoped<Library.Services.v2.IAccountService, Library.Services.v2.AccountService>();
             services.AddScoped<IPurchaseService, PurchaseService>();
             services.AddScoped<IMapperService, MapperService>();
             services.AddScoped<IEmailService, EmailService>();


### PR DESCRIPTION
- Refactored the service layer, so account controller v2 no longer relies on the v1 account service. 
- Added get and update to account controller v2. The new functionality is it now includes all information about a user's programme, not only the ID of it.
- Removed methods from account service v1 that supported functionality in account controller v2
-  Added tests for all methods in AccountService v2