### PR TITLE
Added productName as a property to SimplePurchaseResponse

### DIFF
--- a/coffeecard/CoffeeCard.Library/Services/v2/PurchaseService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/PurchaseService.cs
@@ -175,6 +175,7 @@ namespace CoffeeCard.Library.Services.v2
                     Id = p.Id,
                     DateCreated = p.DateCreated,
                     ProductId = p.ProductId,
+                    ProductName = p.ProductName,
                     TotalAmount = p.Price,
                     PurchaseStatus = p.Status
                 })
@@ -303,6 +304,7 @@ namespace CoffeeCard.Library.Services.v2
                 Id = purchase.Id,
                 DateCreated = purchase.DateCreated,
                 ProductId = purchase.ProductId,
+                ProductName = purchase.ProductName,
                 TotalAmount = purchase.Price,
                 PurchaseStatus = purchase.Status
             };

--- a/coffeecard/CoffeeCard.Library/Services/v2/PurchaseService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/PurchaseService.cs
@@ -176,6 +176,7 @@ namespace CoffeeCard.Library.Services.v2
                     DateCreated = p.DateCreated,
                     ProductId = p.ProductId,
                     ProductName = p.ProductName,
+                    NumberOfTickets = p.NumberOfTickets,
                     TotalAmount = p.Price,
                     PurchaseStatus = p.Status
                 })
@@ -305,6 +306,7 @@ namespace CoffeeCard.Library.Services.v2
                 DateCreated = purchase.DateCreated,
                 ProductId = purchase.ProductId,
                 ProductName = purchase.ProductName,
+                NumberOfTickets = purchase.NumberOfTickets,
                 TotalAmount = purchase.Price,
                 PurchaseStatus = purchase.Status
             };

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Purchase/SimplePurchaseResponse.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Purchase/SimplePurchaseResponse.cs
@@ -51,6 +51,14 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.Purchase
         public String ProductName { get; set; }
         
         /// <summary>
+        /// Number of tickets issued in purchase
+        /// </summary>
+        /// <value>Amount of tickets granted by the purchase</value>
+        /// <example>10</example>
+        [Required]
+        public int NumberOfTickets { get; set; }
+        
+        /// <summary>
         /// Total purchase price in Danish Kroner (kr)
         /// </summary>
         /// <value>Total purchase price</value>

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Purchase/SimplePurchaseResponse.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Purchase/SimplePurchaseResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace CoffeeCard.Models.DataTransferObjects.v2.Purchase
@@ -11,6 +11,7 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.Purchase
     ///     "id": 22,
     ///     "dateCreated": "2022-01-09T21:03:52.2283208Z",
     ///     "productId": 1,
+    ///     "productName": "Filter coffee",
     ///     "totalAmount": 300,
     ///     "purchaseStatus": "Completed"
     /// }
@@ -40,6 +41,14 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.Purchase
         /// <example>1</example>
         [Required]
         public int ProductId { get; set; }
+
+        /// <summary>
+        /// Name of purchased product
+        /// </summary>
+        /// <value>Product Name</value>
+        /// <example>1</example>
+        [Required]
+        public String ProductName { get; set; }
         
         /// <summary>
         /// Total purchase price in Danish Kroner (kr)


### PR DESCRIPTION
Reason for adding: This helps the app when it needs to retrieve receipts, since it can get all required information in one request, instead of having to request the product names separately.