### PR TITLE
ci: Fix format check with dotnet-format

### DIFF
--- a/.github/workflows/core-build.yml
+++ b/.github/workflows/core-build.yml
@@ -23,12 +23,14 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Install dotnet-format
+        run: dotnet tool install -g dotnet-format
       - name: Restore dependencies
         run: dotnet restore coffeecard/
       - name: Build CoffeeCard solution
         run: dotnet build coffeecard/ --no-restore /p:ContinuousIntegrationBuild=true
       - name: Check code formatting
-        run: dotnet format --verify-no-changes coffeecard/
+        run: dotnet-format --no-restore --check coffeecard/
       - name: Run tests
         run: dotnet test coffeecard/ --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
       - name: Upload test coverage to Codecov


### PR DESCRIPTION
Uses `dotnet-format` instead of `dotnet format` to properly check files without throwing an error.