### PR TITLE
fix: Correct where clause in resend verification

### DIFF
--- a/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
@@ -162,7 +162,7 @@ namespace CoffeeCard.Library.Services.v2
         public async Task ResendAccountVerificationEmail(ResendAccountVerificationEmailRequest request)
         {
             var user = await _context.Users
-                .Where(u => u.Email.Equals(request.Email, StringComparison.OrdinalIgnoreCase))
+                .Where(u => u.Email.ToLower().Equals(request.Email.ToLower()))
                 .FirstOrDefaultAsync();
 
             if (user == null)


### PR DESCRIPTION
According to [this article from the EF Core docs](https://learn.microsoft.com/en-us/ef/core/miscellaneous/collations-and-case-sensitivity#translation-of-built-in-net-string-operations), using the `StringComparison` enum in `Equals` does not correctly translate to SQL, and as such EF Core will throw an exception. 

This pull request changes the `Where` clause to simply perform `.ToLower()` on each string, to ensure case-insensitivity 