### PR TITLE
Expose usergroups on getproducts

### DIFF
--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/ProductsController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/ProductsController.cs
@@ -101,7 +101,8 @@ namespace CoffeeCard.WebApi.Controllers.v2
                 Description = product.Description,
                 NumberOfTickets = product.NumberOfTickets,
                 Price = product.Price,
-                IsPerk = product.IsPerk()
+                IsPerk = product.IsPerk(),
+                AllowedUserGroups = product.ProductUserGroup.Select(e => e.UserGroup)
             };
         }
     }


### PR DESCRIPTION
The MapProductToDto in the productscontroller was missing one line that converts the user groups on a product to usergroups on a ProductResponse.

This allows a frontend to actually see the usergroups on a product.