### PR TITLE
Adds GET products/all for privileged users

### DIFF
--- a/coffeecard/CoffeeCard.Library/Services/v2/IProductService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/IProductService.cs
@@ -11,6 +11,7 @@ namespace CoffeeCard.Library.Services.v2
         Task<IEnumerable<Product>> GetPublicProductsAsync();
         Task<IEnumerable<Product>> GetProductsForUserAsync(User user);
         Task<Product> GetProductAsync(int productId);
+        Task<IEnumerable<Product>> GetAllProductsAsync();
         Task<ChangedProductResponse> AddProduct(AddProductRequest product);
 
         Task<ChangedProductResponse> UpdateProduct(UpdateProductRequest product);

--- a/coffeecard/CoffeeCard.Library/Services/v2/ProductService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/ProductService.cs
@@ -40,6 +40,14 @@ namespace CoffeeCard.Library.Services.v2
                 .ToListAsync();
         }
 
+        public async Task<IEnumerable<Product>> GetAllProductsAsync()
+        {
+            return await _context.Products
+                .OrderBy(p => p.Id)
+                .Include(p => p.ProductUserGroup)
+                .ToListAsync();
+        }
+
         public async Task<Product> GetProductAsync(int productId)
         {
             var product = await _context.Products

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Products/ProductResponse.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Products/ProductResponse.cs
@@ -15,6 +15,7 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.Products
     ///     "name": "Coffee clip card",
     ///     "description": "Coffee clip card of 10 clips",
     ///     "isPerk": true,
+    ///     "visible": true,
     ///     "AllowedUserGroups": ["Manager", "Board"]
     /// }
     /// </example>

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Products/ProductResponse.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/Products/ProductResponse.cs
@@ -69,6 +69,14 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.Products
         public bool IsPerk { get; set; }
 
         /// <summary>
+        /// Visibility of products for users
+        /// </summary>
+        /// <value>Product visibility</value>
+        /// <example>true</example>
+        [Required]
+        public bool Visible { get; set; }
+
+        /// <summary>
         /// Decides the user groups that can access the product.
         /// </summary>
         /// <value> Product User Groups </value>

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/v2/ProductServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/v2/ProductServiceTest.cs
@@ -1,6 +1,5 @@
+using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using System.Threading.Tasks;
 using CoffeeCard.Common.Configuration;
 using CoffeeCard.Library.Persistence;
@@ -123,6 +122,127 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             Assert.Collection<UserGroup>(expected,
                 e => e.Equals(UserGroup.Customer),
                 e => e.Equals(UserGroup.Board));
+        }
+
+        [Fact(DisplayName = "GetAllProducts shows non-visible products")]
+        public async Task GetAllProducts_Returns_Non_Visible_Products()
+        {
+            var builder = new DbContextOptionsBuilder<CoffeeCardContext>()
+                .UseInMemoryDatabase(nameof(GetAllProducts_Returns_Non_Visible_Products));
+
+            var databaseSettings = new DatabaseSettings
+            {
+                SchemaName = "test"
+            };
+            var environmentSettings = new EnvironmentSettings()
+            {
+                EnvironmentType = EnvironmentType.Test
+            };
+
+            await using var context = new CoffeeCardContext(builder.Options, databaseSettings, environmentSettings);
+
+            using var productService = new ProductService(context);
+
+            var p1 = new AddProductRequest
+            {
+                Name = "Coffee",
+                Description = "Coffee Clip card",
+                NumberOfTickets = 10,
+                Price = 10,
+                Visible = true,
+                AllowedUserGroups = Enum.GetValues<UserGroup>()
+            };
+            await productService.AddProduct(p1);
+
+            var p2 = new AddProductRequest
+            {
+                Name = "Latte",
+                Description = "Fancy Drink Clip card",
+                NumberOfTickets = 10,
+                Price = 170,
+                Visible = false,
+                AllowedUserGroups = Enum.GetValues<UserGroup>()
+            };
+            await productService.AddProduct(p2);
+
+            var result = await productService.GetAllProductsAsync();
+
+            Assert.Collection(result,
+                e => e.Visible.Equals(true),
+                e => e.Visible.Equals(false));
+        }
+
+        [Fact(DisplayName = "GetAllProducts returns products from all user groups")]
+        public async Task GetAllProducts_Returns_Products_For_All_UserGroups()
+        {
+            var builder = new DbContextOptionsBuilder<CoffeeCardContext>()
+                .UseInMemoryDatabase(nameof(GetAllProducts_Returns_Products_For_All_UserGroups));
+
+            var databaseSettings = new DatabaseSettings
+            {
+                SchemaName = "test"
+            };
+            var environmentSettings = new EnvironmentSettings()
+            {
+                EnvironmentType = EnvironmentType.Test
+            };
+
+            await using var context = new CoffeeCardContext(builder.Options, databaseSettings, environmentSettings);
+
+            using var productService = new ProductService(context);
+
+            var p1 = new AddProductRequest
+            {
+                Name = "Coffee",
+                Description = "Coffee Clip card",
+                NumberOfTickets = 10,
+                Price = 10,
+                Visible = true,
+                AllowedUserGroups = new List<UserGroup> { UserGroup.Customer }
+            };
+            await productService.AddProduct(p1);
+
+            var p2 = new AddProductRequest
+            {
+                Name = "Latte",
+                Description = "Fancy Drink Clip card",
+                NumberOfTickets = 10,
+                Price = 170,
+                Visible = true,
+                AllowedUserGroups = new List<UserGroup> { UserGroup.Barista }
+            };
+            await productService.AddProduct(p2);
+
+            var p3 = new AddProductRequest
+            {
+                Name = "Frappuccino",
+                Description = "Blended ice with sugar",
+                NumberOfTickets = 1,
+                Price = 35,
+                Visible = true,
+                AllowedUserGroups = new List<UserGroup> { UserGroup.Manager }
+            };
+            await productService.AddProduct(p3);
+
+            var p4 = new AddProductRequest
+            {
+                Name = "Cortado",
+                Description = "Some spanish coffee",
+                NumberOfTickets = 1,
+                Price = 19,
+                Visible = true,
+                AllowedUserGroups = new List<UserGroup> { UserGroup.Board }
+            };
+            await productService.AddProduct(p4);
+
+            var result = await productService.GetAllProductsAsync();
+
+            Assert.Collection<Product>(result,
+                e => e.ProductUserGroup = new List<ProductUserGroup> { new ProductUserGroup { UserGroup = UserGroup.Customer } },
+                e => e.ProductUserGroup = new List<ProductUserGroup> { new ProductUserGroup { UserGroup = UserGroup.Barista } },
+                e => e.ProductUserGroup = new List<ProductUserGroup> { new ProductUserGroup { UserGroup = UserGroup.Manager } },
+                e => e.ProductUserGroup = new List<ProductUserGroup> { new ProductUserGroup { UserGroup = UserGroup.Board } }
+            );
         }
     }
 }

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/v2/ProductServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/v2/ProductServiceTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using CoffeeCard.Common.Configuration;
 using CoffeeCard.Library.Persistence;
@@ -69,16 +70,14 @@ namespace CoffeeCard.Tests.Unit.Services.v2
                 AllowedUserGroups = new List<UserGroup>() { UserGroup.Customer, UserGroup.Board }
             });
 
-            var expected = new List<UserGroup>
-            {
-                UserGroup.Customer, UserGroup.Board
-            };
-
             var result = await productService.GetProductAsync(1);
 
-            Assert.Collection<UserGroup>(expected,
-                e => e.Equals(UserGroup.Customer),
-                e => e.Equals(UserGroup.Board));
+            Assert.Collection<ProductUserGroup>(result.ProductUserGroup,
+                e => Assert.Equal(UserGroup.Customer, e.UserGroup),
+                e => Assert.Equal(UserGroup.Board, e.UserGroup));
+
+            Assert.DoesNotContain(UserGroup.Barista, result.ProductUserGroup.Select(e => e.UserGroup));
+            Assert.DoesNotContain(UserGroup.Manager, result.ProductUserGroup.Select(e => e.UserGroup));
         }
 
         [Fact(DisplayName = "AddProduct adds only selected user groups")]
@@ -112,16 +111,11 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             await productService.AddProduct(p);
 
-            var expected = new List<UserGroup>
-            {
-                UserGroup.Manager, UserGroup.Board
-            };
-
             var result = await productService.GetProductAsync(1);
 
-            Assert.Collection<UserGroup>(expected,
-                e => e.Equals(UserGroup.Customer),
-                e => e.Equals(UserGroup.Board));
+            Assert.Collection<ProductUserGroup>(result.ProductUserGroup,
+                e => Assert.Equal(UserGroup.Manager, e.UserGroup),
+                e => Assert.Equal(UserGroup.Board, e.UserGroup));
         }
 
         [Fact(DisplayName = "GetAllProducts shows non-visible products")]

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/v2/ProductServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/v2/ProductServiceTest.cs
@@ -76,6 +76,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
                 e => Assert.Equal(UserGroup.Customer, e.UserGroup),
                 e => Assert.Equal(UserGroup.Board, e.UserGroup));
 
+            // Explicitly check for exclusion of Barista and Manager, even though Assert.Collection implicitly covers it.
             Assert.DoesNotContain(UserGroup.Barista, result.ProductUserGroup.Select(e => e.UserGroup));
             Assert.DoesNotContain(UserGroup.Manager, result.ProductUserGroup.Select(e => e.UserGroup));
         }

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/ProductsController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/ProductsController.cs
@@ -102,8 +102,23 @@ namespace CoffeeCard.WebApi.Controllers.v2
                 NumberOfTickets = product.NumberOfTickets,
                 Price = product.Price,
                 IsPerk = product.IsPerk(),
+                Visible = product.Visible,
                 AllowedUserGroups = product.ProductUserGroup.Select(e => e.UserGroup)
             };
+        }
+
+        /// <summary>
+        /// Returns a list of all products
+        /// </summary>
+        /// <returns>List of all products</returns>
+        /// <response code="200">Successful request</response>
+        [HttpGet("all")]
+        [AuthorizeRoles(UserGroup.Board)]
+        [ProducesResponseType(typeof(IEnumerable<ProductResponse>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<ProductResponse>>> GetAllProducts()
+        {
+            IEnumerable<Product> products = await _productService.GetAllProductsAsync();
+            return Ok(products.Select(MapProductToDto).ToList());
         }
     }
 }


### PR DESCRIPTION
Some weird merge conflicts arised on #232 after #234 was made. Probably due to me branching out from the wrong branch initially. Here is a new pull request instead :)

This adds an endpoint for the product management with frontend in https://github.com/AnalogIO/shifty-webapp/pull/20 and discussed as endpoint in #217 (and slack).

The API will have the endpoint /api/v2/products/all which gives all products, not restricted to a specific usergroup or restricted to only visible products.

This endpoint is only accessible for users with Board privileges and will allow board members to manage the visibilty of products or products that they otherwise don't have access to themselves in the app.