### PR TITLE
Search returns single element that contains list

### DIFF
--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/AccountController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/AccountController.cs
@@ -218,9 +218,9 @@ namespace CoffeeCard.WebApi.Controllers.v2
         [HttpGet]
         [AuthorizeRoles(UserGroup.Board)]
         [ProducesResponseType(typeof(ApiError), StatusCodes.Status401Unauthorized)]
-        [ProducesResponseType(typeof(IEnumerable<UserSearchResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(UserSearchResponse), StatusCodes.Status200OK)]
         [Route("search")]
-        public async Task<ActionResult<IEnumerable<UserSearchResponse>>> SearchUsers([FromQuery][Range(0, int.MaxValue)] int pageNum, [FromQuery] string filter = "", [FromQuery][Range(1, 100)] int pageLength = 30)
+        public async Task<ActionResult<UserSearchResponse>> SearchUsers([FromQuery][Range(0, int.MaxValue)] int pageNum, [FromQuery] string filter = "", [FromQuery][Range(1, 100)] int pageLength = 30)
         {
             return Ok(await _accountService.SearchUsers(filter, pageNum, pageLength));
         }


### PR DESCRIPTION
See below screenshot showing that the service returns a `UserSearchResponse` and not an enumerable.
![image](https://github.com/AnalogIO/analog-core/assets/95026056/34f1e783-c10c-4cbc-a870-d86e2611186a)

This affects Shifty when we use the GenerateApi tool and the generated code expects to return a list.

A `UserSearchResponse` contains an enumerable of SimpleUserResponse and a TotalUsers (count) property. 