### PR TITLE
Webhook for bulk updating accounts usergroup

### DIFF
--- a/coffeecard/CoffeeCard.Library/CoffeeCard.Library.csproj
+++ b/coffeecard/CoffeeCard.Library/CoffeeCard.Library.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>default</LangVersion>
@@ -9,7 +9,6 @@
     <PackageReference Include="MimeKit" Version="3.4.2" />
     <PackageReference Include="NetEscapades.Configuration.Validation" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     <PackageReference Include="RestSharp" Version="108.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />

--- a/coffeecard/CoffeeCard.Library/Migrations/20240227174524_AddUserGroupIndexToUsers.Designer.cs
+++ b/coffeecard/CoffeeCard.Library/Migrations/20240227174524_AddUserGroupIndexToUsers.Designer.cs
@@ -4,6 +4,7 @@ using CoffeeCard.Library.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CoffeeCard.Library.Migrations
 {
     [DbContext(typeof(CoffeeCardContext))]
-    partial class CoffeeCardContextModelSnapshot : ModelSnapshot
+    [Migration("20240227174524_AddUserGroupIndexToUsers")]
+    partial class AddUserGroupIndexToUsers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/coffeecard/CoffeeCard.Library/Migrations/20240227174524_AddUserGroupIndexToUsers.cs
+++ b/coffeecard/CoffeeCard.Library/Migrations/20240227174524_AddUserGroupIndexToUsers.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CoffeeCard.Library.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserGroupIndexToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_UserGroup",
+                schema: "dbo",
+                table: "Users",
+                column: "UserGroup");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_UserGroup",
+                schema: "dbo",
+                table: "Users");
+        }
+    }
+}

--- a/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
@@ -323,7 +323,7 @@ namespace CoffeeCard.Library.Services.v2
 
                 if (hash.Equals(cachedHash))
                 {
-                    Log.Information($"Duplicate update usergroup request detected: {hash}");
+                    Log.Information("Duplicate update user group request detected: {hash}", hash);
                     return;
                 }
             }

--- a/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
@@ -297,7 +297,7 @@ namespace CoffeeCard.Library.Services.v2
 
             if (request.Hash.Equals(cachedHash))
             {
-                Log.Information($"Hash seen before: {request.Hash}");
+                Log.Information($"Duplicate update usergroup request detected: {request.Hash}");
                 return;
             }
 

--- a/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/AccountService.cs
@@ -285,8 +285,6 @@ namespace CoffeeCard.Library.Services.v2
         {
             if (!_memoryCache.TryGetValue(AccountsWebhooksHashCacheKey, out string cachedHash))
             {
-                cachedHash = request.Hash;
-
                 var cacheExpiryOptions = new MemoryCacheEntryOptions
                 {
                     AbsoluteExpiration = DateTime.UtcNow.AddHours(48),
@@ -294,14 +292,15 @@ namespace CoffeeCard.Library.Services.v2
                 };
 
                 Log.Information("Set {AccountsWebhooksHashCacheKey} in Cache", AccountsWebhooksHashCacheKey);
-                _memoryCache.Set(AccountsWebhooksHashCacheKey, cachedHash, cacheExpiryOptions);
+                _memoryCache.Set(AccountsWebhooksHashCacheKey, request.Hash, cacheExpiryOptions);
             }
 
-            if (cachedHash.Equals(request.Hash)) {
+            if (request.Hash.Equals(cachedHash))
+            {
+                Log.Information($"Hash seen before: {request.Hash}");
                 return;
             }
 
-            // TODO: Fix Bulk Update in EFCore 6
             await _context.Users
                 .Where(u => u.UserGroup != UserGroup.Customer)
                 .ExecuteUpdateAsync(u => u.SetProperty(u => u.UserGroup, UserGroup.Customer));

--- a/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/IAccountService.cs
@@ -72,5 +72,10 @@ namespace CoffeeCard.Library.Services.v2
         /// <param name="pageNum"> The page number </param>
         /// <param name="pageLength"> The length of a page </param>
         Task<UserSearchResponse> SearchUsers(String search, int pageNum, int pageLength);
+
+        /// <summary>
+        /// Remove all existing priviliged user group assignments. Update users based on request contents
+        /// </summary>
+        Task UpdatePriviligedUserGroups(WebhookUpdateUserGroupRequest request);
     }
 }

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/AccountUserGroup.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/AccountUserGroup.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace CoffeeCard.Models.Entities;
 
 /// <summary>
@@ -10,6 +12,7 @@ public class AccountUserGroup
     /// </summary>
     /// <value> Account id </value>
     /// <example>1</example>
+    [Required]
     public int AccountId { get; set; }
 
     /// <summary>
@@ -17,5 +20,6 @@ public class AccountUserGroup
     /// </summary>
     /// <value> User group </value>
     /// <example>Barista</example>
+    [Required]
     public UserGroup UserGroup { get; set; }
 }

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
@@ -1,0 +1,13 @@
+﻿using CoffeeCard.Models.Entities;
+using System.Collections.Generic;
+
+namespace CoffeeCard.Models.DataTransferObjects.v2.User
+{
+    public class WebhookUpdateUserGroupRequest
+    {
+        public string Hash { get; set; }
+
+        // TODO Use custom object instead
+        public IEnumerable<(int AccountId, UserGroup UserGroup)> PrivilegedUsers { get; set;}
+    }
+}

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
@@ -3,11 +3,19 @@ using System.Collections.Generic;
 
 namespace CoffeeCard.Models.DataTransferObjects.v2.User
 {
+    /// <summary>
+    /// Represents a request to update user groups in bulk
+    /// </summary>
     public class WebhookUpdateUserGroupRequest
     {
+        /// <summary>
+        /// The hash of the request
+        /// </summary>
         public string Hash { get; set; }
 
-        // TODO Use custom object instead
-        public IEnumerable<(int AccountId, UserGroup UserGroup)> PrivilegedUsers { get; set;}
+        /// <summary>
+        /// List of accounts and their new user groups
+        /// </summary>
+        public IEnumerable<AccountUserGroup> PrivilegedUsers { get; set; }
     }
 }

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
@@ -9,11 +9,6 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.User
     public class WebhookUpdateUserGroupRequest
     {
         /// <summary>
-        /// The hash of the request
-        /// </summary>
-        public string Hash { get; set; }
-
-        /// <summary>
         /// List of accounts and their new user groups
         /// </summary>
         public IEnumerable<AccountUserGroup> PrivilegedUsers { get; set; }

--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/WebhookUpdateUserGroupRequest.cs
@@ -1,5 +1,6 @@
 ﻿using CoffeeCard.Models.Entities;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace CoffeeCard.Models.DataTransferObjects.v2.User
 {
@@ -11,6 +12,8 @@ namespace CoffeeCard.Models.DataTransferObjects.v2.User
         /// <summary>
         /// List of accounts and their new user groups
         /// </summary>
+
+        [Required]
         public IEnumerable<AccountUserGroup> PrivilegedUsers { get; set; }
     }
 }

--- a/coffeecard/CoffeeCard.Models/Entities/AccountUserGroup.cs
+++ b/coffeecard/CoffeeCard.Models/Entities/AccountUserGroup.cs
@@ -1,0 +1,21 @@
+namespace CoffeeCard.Models.Entities;
+
+/// <summary>
+/// Represents an account user group update
+/// </summary>
+public class AccountUserGroup
+{
+    /// <summary>
+    /// The account id
+    /// </summary>
+    /// <value> Account id </value>
+    /// <example>1</example>
+    public int AccountId { get; set; }
+
+    /// <summary>
+    /// The user group
+    /// </summary>
+    /// <value> User group </value>
+    /// <example>Barista</example>
+    public UserGroup UserGroup { get; set; }
+}

--- a/coffeecard/CoffeeCard.Models/Entities/User.cs
+++ b/coffeecard/CoffeeCard.Models/Entities/User.cs
@@ -9,6 +9,7 @@ namespace CoffeeCard.Models.Entities
 {
     [Index(nameof(Email))]
     [Index(nameof(Name))]
+    [Index(nameof(UserGroup))]
     public class User
     {
         public int Id { get; set; }

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/v2/AccountServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/v2/AccountServiceTest.cs
@@ -16,7 +16,6 @@ using CoffeeCard.Models.DataTransferObjects.v2.User;
 using CoffeeCard.Models.Entities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.IdentityModel.Tokens;
 using Moq;
 using Xunit;
@@ -55,7 +54,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
             result = await accountService.GetAccountByClaimsAsync(claims);
 
             // Assert
@@ -75,7 +74,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
 
             // Assert
             await Assert.ThrowsAsync<ApiException>(async () => await accountService.GetAccountByClaimsAsync(claims));
@@ -122,7 +121,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                emailService, hashService, new Mock<IMemoryCache>().Object);
+                emailService, hashService);
             result = await accountService.RegisterAccountAsync(name, email, password, programmeId);
 
             // Assert
@@ -150,7 +149,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, hashservice.Object, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, hashservice.Object);
 
             // Assert
             // Register the first user
@@ -168,7 +167,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             using var context = CreateTestCoffeeCardContextWithName(nameof(RegisterAccountThrowsApiExceptionWithStatus400WhenGivenInvalidProgrammeId));
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
 
             // Assert
             var exception = await Assert.ThrowsAsync<ApiException>(
@@ -211,7 +210,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                emailService, hashService, new Mock<IMemoryCache>().Object);
+                emailService, hashService);
             await accountService.RegisterAccountAsync("name", "email", "password", 1);
 
             // Assert
@@ -277,7 +276,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, hashService, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, hashService);
             var result = await accountService.UpdateAccountAsync(user, updateUserRequest);
 
             // Assert
@@ -324,7 +323,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
 
             // Assert
             var exception = await Assert.ThrowsAsync<ApiException>(async () => await accountService.UpdateAccountAsync(user, updateUserRequest));
@@ -353,7 +352,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                emailService, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+                emailService, new Mock<IHashService>().Object);
 
             await accountService.RequestAnonymizationAsync(user);
             // Assert
@@ -395,7 +394,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, tokenServiceMock.Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
 
             await accountService.AnonymizeAccountAsync("test");
             var result = await context.Users.Where(u => u.Id == user.Id).FirstAsync();
@@ -433,7 +432,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var emailService = new Mock<IEmailService>();
-            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, emailService.Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, emailService.Object, new Mock<IHashService>().Object);
 
             await accountService.ResendAccountVerificationEmail(new ResendAccountVerificationEmailRequest
             {
@@ -466,7 +465,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
 
             // Act
-            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
 
             await Assert.ThrowsAsync<ConflictException>(async () => await accountService.ResendAccountVerificationEmail(new ResendAccountVerificationEmailRequest
             {
@@ -481,7 +480,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await using var context = CreateTestCoffeeCardContextWithName(nameof(ResendVerificationEmailThrowsEntityNotFoundExceptionWhenEmailDoesnotExist));
 
             // Act
-            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
 
             await Assert.ThrowsAsync<EntityNotFoundException>(async () => await accountService.ResendAccountVerificationEmail(new ResendAccountVerificationEmailRequest
             {

--- a/coffeecard/CoffeeCard.Tests.Unit/Services/v2/AccountServiceTest.cs
+++ b/coffeecard/CoffeeCard.Tests.Unit/Services/v2/AccountServiceTest.cs
@@ -16,6 +16,7 @@ using CoffeeCard.Models.DataTransferObjects.v2.User;
 using CoffeeCard.Models.Entities;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.IdentityModel.Tokens;
 using Moq;
 using Xunit;
@@ -54,7 +55,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
             result = await accountService.GetAccountByClaimsAsync(claims);
 
             // Assert
@@ -74,7 +75,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             // Assert
             await Assert.ThrowsAsync<ApiException>(async () => await accountService.GetAccountByClaimsAsync(claims));
@@ -121,7 +122,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                emailService, hashService);
+                emailService, hashService, new Mock<IMemoryCache>().Object);
             result = await accountService.RegisterAccountAsync(name, email, password, programmeId);
 
             // Assert
@@ -149,7 +150,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, hashservice.Object);
+                new Mock<IEmailService>().Object, hashservice.Object, new Mock<IMemoryCache>().Object);
 
             // Assert
             // Register the first user
@@ -167,7 +168,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             using var context = CreateTestCoffeeCardContextWithName(nameof(RegisterAccountThrowsApiExceptionWithStatus400WhenGivenInvalidProgrammeId));
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             // Assert
             var exception = await Assert.ThrowsAsync<ApiException>(
@@ -210,7 +211,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                emailService, hashService);
+                emailService, hashService, new Mock<IMemoryCache>().Object);
             await accountService.RegisterAccountAsync("name", "email", "password", 1);
 
             // Assert
@@ -276,7 +277,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, hashService);
+                new Mock<IEmailService>().Object, hashService, new Mock<IMemoryCache>().Object);
             var result = await accountService.UpdateAccountAsync(user, updateUserRequest);
 
             // Assert
@@ -323,7 +324,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             // Assert
             var exception = await Assert.ThrowsAsync<ApiException>(async () => await accountService.UpdateAccountAsync(user, updateUserRequest));
@@ -352,7 +353,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object,
-                emailService, new Mock<IHashService>().Object);
+                emailService, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             await accountService.RequestAnonymizationAsync(user);
             // Assert
@@ -394,7 +395,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var accountService = new Library.Services.v2.AccountService(context, tokenServiceMock.Object,
-                new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+                new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             await accountService.AnonymizeAccountAsync("test");
             var result = await context.Users.Where(u => u.Id == user.Id).FirstAsync();
@@ -432,7 +433,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
 
             // Act
             var emailService = new Mock<IEmailService>();
-            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, emailService.Object, new Mock<IHashService>().Object);
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, emailService.Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             await accountService.ResendAccountVerificationEmail(new ResendAccountVerificationEmailRequest
             {
@@ -465,7 +466,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await context.SaveChangesAsync();
 
             // Act
-            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             await Assert.ThrowsAsync<ConflictException>(async () => await accountService.ResendAccountVerificationEmail(new ResendAccountVerificationEmailRequest
             {
@@ -480,7 +481,7 @@ namespace CoffeeCard.Tests.Unit.Services.v2
             await using var context = CreateTestCoffeeCardContextWithName(nameof(ResendVerificationEmailThrowsEntityNotFoundExceptionWhenEmailDoesnotExist));
 
             // Act
-            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object);
+            var accountService = new Library.Services.v2.AccountService(context, new Mock<ITokenService>().Object, new Mock<IEmailService>().Object, new Mock<IHashService>().Object, new Mock<IMemoryCache>().Object);
 
             await Assert.ThrowsAsync<EntityNotFoundException>(async () => await accountService.ResendAccountVerificationEmail(new ResendAccountVerificationEmailRequest
             {

--- a/coffeecard/CoffeeCard.WebApi/CoffeeCard.WebApi.csproj
+++ b/coffeecard/CoffeeCard.WebApi/CoffeeCard.WebApi.csproj
@@ -34,7 +34,6 @@
     <PackageReference Include="NetEscapades.Configuration.Validation" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.10" />
     <PackageReference Include="NSwag.AspNetCore" Version="14.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/WebhooksController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/WebhooksController.cs
@@ -1,0 +1,35 @@
+﻿using CoffeeCard.Library.Services.v2;
+using CoffeeCard.Models.DataTransferObjects.v2.User;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace CoffeeCard.WebApi.Controllers.v2
+{
+    /// <summary>
+    /// Controller for creating and managing user accounts
+    /// </summary>
+    [ApiController]
+    [ApiVersion("2")]
+    [Route("api/v{version:apiVersion}/webhooks")]
+    [Authorize(AuthenticationSchemes = "apikey")]
+    public class WebhooksController : ControllerBase
+    {
+        private readonly IAccountService _accountService;
+
+        public WebhooksController(IAccountService accountService)
+        {
+            _accountService = accountService;
+        }
+
+        [HttpPut("/accounts/user-group")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpdateUserGroupsAsync([FromBody][Required] WebhookUpdateUserGroupRequest request)
+        {
+            await _accountService.UpdatePriviligedUserGroups(request);
+            return NoContent();
+        }
+    }
+}

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/WebhooksController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/WebhooksController.cs
@@ -19,18 +19,28 @@ namespace CoffeeCard.WebApi.Controllers.v2
     {
         private readonly IAccountService _accountService;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebhooksController"/> class.
+        /// </summary>
         public WebhooksController(IAccountService accountService)
         {
             _accountService = accountService;
         }
 
+        /// <summary>
+        /// Update user groups in bulk
+        /// </summary>
+        /// <param name="request">The request containing the new user groups</param>
+        /// <returns>No content</returns>
+        /// <response code="204">The user groups were updated</response>
+        /// <response code="400">Bad request. See explanation</response>
+        /// <response code="401">Invalid credentials</response>
         [HttpPut("accounts/user-group")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> UpdateUserGroupsAsync([FromBody][Required] WebhookUpdateUserGroupRequest request)
         {
-
             await _accountService.UpdatePriviligedUserGroups(request);
             return NoContent();
         }

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/WebhooksController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/WebhooksController.cs
@@ -24,10 +24,13 @@ namespace CoffeeCard.WebApi.Controllers.v2
             _accountService = accountService;
         }
 
-        [HttpPut("/accounts/user-group")]
+        [HttpPut("accounts/user-group")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> UpdateUserGroupsAsync([FromBody][Required] WebhookUpdateUserGroupRequest request)
         {
+
             await _accountService.UpdatePriviligedUserGroups(request);
             return NoContent();
         }


### PR DESCRIPTION
Implements the endpoint `PUT /api/v2/webhooks/accounts/user-group`,
allowing an external service to update user groups in bulk.

Example request body:
```
{
   "privilegedUsers": [
       { "accountId": 123, "userGroup": "Manager" },
       { "accountId": 124, "userGroup": "Barista" }
    ]
}
```

The X-Api-Key header should be present on the request with a valid API
key.

The userGroup should be one of:
- Barista
- Manager
- Board
- (Customer will also work, but will have the same effect as not
specifying the user in the request)

### Notes on testing

I have been unable to implement an integration test, since
EFCore.InMemory does not seem to support the performance-optimized
ExecuteUpdate that is implemented in EF Core 7 and used in this service.
Reference:
https://stackoverflow.com/questions/74907256/ef-7-new-executedelete-and-executeupdate-methods-not-working-on-an-in-memory-d

### Business logic

Initially, business logic was implemented using client-side hashing to verify duplicate requests did not use many resources. Later, it was changed to server-side hashing however hashing was completely removed again, as it would cause weird behaviour in combination with the below mentioned existing endpoint. Now it will be clearer that the state in the external system will correct itself if analog-core and the external system are out of sync.

### Notes on affected existing endpoints

This change will also mark our `PATCH /api/v2/account/<id>/user-group`
endpoint, as any calls to the new endpoint will override any user-groups
set by the old patch endpoint.
The endpoint is used by the Shifty User Manager from https://github.com/AnalogIO/shifty-webapp/pull/21
