### PR TITLE
Changes Users to property

### DIFF
--- a/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/UserSearchResponse.cs
+++ b/coffeecard/CoffeeCard.Models/DataTransferObjects/v2/User/UserSearchResponse.cs
@@ -32,5 +32,5 @@ public class UserSearchResponse
     ///  ]
     /// </example>
     [Required]
-    public IEnumerable<SimpleUserResponse> Users;
+    public IEnumerable<SimpleUserResponse> Users { get; set; }
 }


### PR DESCRIPTION
With the new Json serializer from #266, fields are no longer serialized.

Preferably, we would have added the Json options `options.JsonSerializerOptions.IncludeFields = true;` to ensure that no other functionality broke. However, due to an issue raised [here](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2423), the schema in Swagger will not show fields despite setting this option. Thus, our API-generation would not work for e.g. Shifty that uses this.

Instead, I have looked through `CoffeeCard.Models` and not found other examples where we are using fields and not properties.