### PR TITLE
Introduce Feature Flag to control MobilePay Webhooks registration

### DIFF
--- a/coffeecard/CoffeeCard.Library/CoffeeCard.Library.csproj
+++ b/coffeecard/CoffeeCard.Library/CoffeeCard.Library.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageReference Include="MailKit" Version="3.4.2" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.2.0" />
     <PackageReference Include="MimeKit" Version="3.4.2" />
     <PackageReference Include="NetEscapades.Configuration.Validation" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/coffeecard/CoffeeCard.Library/Services/v2/WebhookService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/WebhookService.cs
@@ -26,7 +26,6 @@ namespace CoffeeCard.Library.Services.v2
         private readonly IMobilePayWebhooksService _mobilePayWebhooksService;
         private readonly MobilePaySettingsV2 _mobilePaySettings;
         private readonly IMemoryCache _memoryCache;
-        private readonly IFeatureManager _featureManager;
 
         public WebhookService(CoffeeCardContext context, IMobilePayWebhooksService mobilePayWebhooksService,
             MobilePaySettingsV2 mobilePaySettings, IMemoryCache memoryCache)

--- a/coffeecard/CoffeeCard.Library/Services/v2/WebhookService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/WebhookService.cs
@@ -10,6 +10,7 @@ using CoffeeCard.MobilePay.Service.v2;
 using CoffeeCard.Models.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.FeatureManagement;
 using Serilog;
 
 namespace CoffeeCard.Library.Services.v2
@@ -25,6 +26,7 @@ namespace CoffeeCard.Library.Services.v2
         private readonly IMobilePayWebhooksService _mobilePayWebhooksService;
         private readonly MobilePaySettingsV2 _mobilePaySettings;
         private readonly IMemoryCache _memoryCache;
+        private readonly IFeatureManager _featureManager;
 
         public WebhookService(CoffeeCardContext context, IMobilePayWebhooksService mobilePayWebhooksService,
             MobilePaySettingsV2 mobilePaySettings, IMemoryCache memoryCache)
@@ -86,16 +88,6 @@ namespace CoffeeCard.Library.Services.v2
                     await DisableAndRegisterNewWebhook(webhook);
                     return;
                 }
-
-                mobilePayWebhook = await _mobilePayWebhooksService.UpdateWebhook(mobilePayWebhook.WebhookId,
-                    _mobilePaySettings.WebhookUrl, DefaultEvents);
-
-                webhook.Url = mobilePayWebhook.Url;
-                webhook.SignatureKey = mobilePayWebhook.SignatureKey;
-                webhook.Status = WebhookStatus.Active;
-                webhook.LastUpdated = DateTime.UtcNow;
-
-                await _context.SaveChangesAsync();
             }
             catch (EntityNotFoundException)
             {

--- a/coffeecard/CoffeeCard.Library/Utils/FeatureFlags.cs
+++ b/coffeecard/CoffeeCard.Library/Utils/FeatureFlags.cs
@@ -1,0 +1,10 @@
+﻿namespace CoffeeCard.Library.Utils
+{
+    public class FeatureFlags
+    {
+        /// <summary>
+        /// Controls whether the API should manage the registration to the MobilePayWebhooks API at startup. Disabling this feature flag, assumes that the Webhook Registration is handled outside of the Analog Core API.
+        /// </summary>
+        public const string MobilePayManageWebhookRegistration = "MobilePayManageWebhookRegistration";
+    }
+}

--- a/coffeecard/CoffeeCard.WebApi/CoffeeCard.WebApi.csproj
+++ b/coffeecard/CoffeeCard.WebApi/CoffeeCard.WebApi.csproj
@@ -22,8 +22,6 @@
     <Compile Remove="Migrations\20200229143937_ProductUserGroups.Designer.cs" />
   </ItemGroup>
   <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="AspNetCore.Authentication.ApiKey" Version="7.0.0" />
     <PackageReference Include="jose-jwt" Version="4.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
@@ -31,6 +29,7 @@
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.2.0" />
     <PackageReference Include="NetEscapades.Configuration.Validation" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/coffeecard/CoffeeCard.WebApi/Program.cs
+++ b/coffeecard/CoffeeCard.WebApi/Program.cs
@@ -4,12 +4,14 @@ using System.Threading.Tasks;
 using CoffeeCard.Common.Configuration;
 using CoffeeCard.Library.Persistence;
 using CoffeeCard.Library.Services.v2;
+using CoffeeCard.Library.Utils;
 using CoffeeCard.WebApi.Logging;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.FeatureManagement;
 using Serilog;
 
 namespace CoffeeCard.WebApi
@@ -55,7 +57,7 @@ namespace CoffeeCard.WebApi
             return Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration(((context, builder) =>
                 {
-                    builder.AddJsonFile("appsettings.json", false, true);
+                    builder.AddJsonFile(path: "appsettings.json", optional: false, reloadOnChange: true);
                     builder.AddEnvironmentVariables();
                 }))
                 .ConfigureWebHostDefaults(webBuilder =>
@@ -69,6 +71,7 @@ namespace CoffeeCard.WebApi
         {
             using var serviceScope = webhost.Services.CreateScope();
             var environment = serviceScope.ServiceProvider.GetRequiredService<EnvironmentSettings>();
+            var featureManager = serviceScope.ServiceProvider.GetRequiredService<IFeatureManager>();
 
             Log.Information("Apply Database Migrations if any");
             await using var context = serviceScope.ServiceProvider.GetRequiredService<CoffeeCardContext>();
@@ -77,7 +80,10 @@ namespace CoffeeCard.WebApi
                 context.Database.Migrate();
             }
 
-            if (environment.EnvironmentType != EnvironmentType.LocalDevelopment)
+            var isMobilePayWebhookRegistrationManagementEnabled = await featureManager.IsEnabledAsync(FeatureFlags.MobilePayManageWebhookRegistration);
+            Log.Information("FeatureFlag {flag} has enablement state '{value}'", nameof(FeatureFlags.MobilePayManageWebhookRegistration), isMobilePayWebhookRegistrationManagementEnabled);
+
+            if (environment.EnvironmentType != EnvironmentType.LocalDevelopment && isMobilePayWebhookRegistrationManagementEnabled)
             {
                 var webhookService = serviceScope.ServiceProvider.GetRequiredService<IWebhookService>();
                 await webhookService.EnsureWebhookIsRegistered();

--- a/coffeecard/CoffeeCard.WebApi/Startup.cs
+++ b/coffeecard/CoffeeCard.WebApi/Startup.cs
@@ -23,6 +23,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
@@ -94,6 +95,7 @@ namespace CoffeeCard.WebApi
             services.AddScoped<Library.Services.v2.ILeaderboardService, Library.Services.v2.LeaderboardService>();
             services.AddScoped<IStatisticService, StatisticService>();
             services.AddScoped<IDateTimeProvider, DateTimeProvider>();
+            services.AddFeatureManagement();
 
             // Azure Application Insights
             services.AddApplicationInsightsTelemetry();

--- a/coffeecard/CoffeeCard.WebApi/appsettings.json
+++ b/coffeecard/CoffeeCard.WebApi/appsettings.json
@@ -60,5 +60,8 @@
         }
       }
     ]
+  },
+  "FeatureManagement": {
+    "MobilePayManageWebhookRegistration": false
   }
 }


### PR DESCRIPTION
When migrating to the new MobilePay Vipps API, the existing MobilePay Webhooks API will be disabled, thus we need a way to disable the feature until the new integration has been developed. We use Feature Flags to disable registration to the Webhooks API.