### PR TITLE
Adds manager access to issue vouchers

### DIFF
--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/ProductsController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/ProductsController.cs
@@ -108,7 +108,7 @@ namespace CoffeeCard.WebApi.Controllers.v2
         /// <returns>List of all products</returns>
         /// <response code="200">Successful request</response>
         [HttpGet("all")]
-        [AuthorizeRoles(UserGroup.Board)]
+        [AuthorizeRoles(UserGroup.Board, UserGroup.Manager)]
         [ProducesResponseType(typeof(IEnumerable<ProductResponse>), StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<ProductResponse>>> GetAllProducts()
         {

--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/VouchersController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/VouchersController.cs
@@ -49,7 +49,7 @@ namespace CoffeeCard.WebApi.Controllers.v2
         [ProducesResponseType(typeof(ApiError), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(typeof(void), StatusCodes.Status403Forbidden)]
-        [AuthorizeRoles(UserGroup.Board)]
+        [AuthorizeRoles(UserGroup.Board, UserGroup.Manager)]
         [HttpPost("issue-vouchers")]
         public async Task<ActionResult<IEnumerable<IssueVoucherResponse>>> IssueVouchers([FromBody] IssueVoucherRequest request)
         {


### PR DESCRIPTION
Users with role Manager can now (alongside users with role Board) issue vouchers, which also includes access to the products/all endpoint. 
This is required to list products available to issue products on. (This endpoint is used for issuing vouchers as well as the product manager but nowhere else. The endpoint for products that is usable per user group used by the app is a different endpoint)