### PR TITLE
Add EmailSender abstraction for sending mails using either SMTP or Mailgun

### DIFF
--- a/coffeecard/CoffeeCard.Common/Configuration/SmtpSettings.cs
+++ b/coffeecard/CoffeeCard.Common/Configuration/SmtpSettings.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using NetEscapades.Configuration.Validation;
 
 namespace CoffeeCard.Common.Configuration
 {

--- a/coffeecard/CoffeeCard.Common/Configuration/SmtpSettings.cs
+++ b/coffeecard/CoffeeCard.Common/Configuration/SmtpSettings.cs
@@ -3,15 +3,10 @@ using NetEscapades.Configuration.Validation;
 
 namespace CoffeeCard.Common.Configuration
 {
-    public class SmtpSettings : IValidatable
+    public class SmtpSettings
     {
         [Required] public string Host { get; set; }
         [Required] public int Port { get; set; }
-
-        public void Validate()
-        {
-            Validator.ValidateObject(this, new ValidationContext(this), true);
-        }
     }
 }
 

--- a/coffeecard/CoffeeCard.Common/Configuration/SmtpSettings.cs
+++ b/coffeecard/CoffeeCard.Common/Configuration/SmtpSettings.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using NetEscapades.Configuration.Validation;
+
+namespace CoffeeCard.Common.Configuration
+{
+    public class SmtpSettings : IValidatable
+    {
+        [Required] public string Host { get; set; }
+        [Required] public int Port { get; set; }
+
+        public void Validate()
+        {
+            Validator.ValidateObject(this, new ValidationContext(this), true);
+        }
+    }
+}
+

--- a/coffeecard/CoffeeCard.Library/Services/IEmailSender.cs
+++ b/coffeecard/CoffeeCard.Library/Services/IEmailSender.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using MimeKit;
+
+namespace CoffeeCard.Library.Services;
+
+public interface IEmailSender
+{
+    public Task SendEmailAsync(MimeMessage email);
+}

--- a/coffeecard/CoffeeCard.Library/Services/MailgunEmailSender.cs
+++ b/coffeecard/CoffeeCard.Library/Services/MailgunEmailSender.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using CoffeeCard.Common.Configuration;
+using MimeKit;
+using RestSharp;
+using RestSharp.Authenticators;
+using Serilog;
+
+namespace CoffeeCard.Library.Services;
+
+public class MailgunEmailSender(MailgunSettings mailgunSettings) : IEmailSender
+{
+    public async Task SendEmailAsync(MimeMessage mail)
+    {
+        var client = new RestClient(mailgunSettings.MailgunApiUrl)
+        {
+            Authenticator = new HttpBasicAuthenticator("api", mailgunSettings.ApiKey)
+        };
+
+        var request = new RestRequest();
+        request.AddParameter("domain", mailgunSettings.Domain, ParameterType.UrlSegment);
+        request.Resource = "{domain}/messages";
+        request.AddParameter("from", "Cafe Analog <mailgun@cafeanalog.dk>");
+        request.AddParameter("to", mail.To[0].ToString());
+        request.AddParameter("subject", mail.Subject);
+        request.AddParameter("html", mail.HtmlBody);
+        request.Method = Method.Post;
+
+        var response = await client.ExecutePostAsync(request);
+
+        if (!response.IsSuccessful)
+        {
+            Log.Error("Error sending request to Mailgun. StatusCode: {statusCode} ErrorMessage: {errorMessage}",
+                response.StatusCode, response.ErrorMessage);
+        }
+    }
+}

--- a/coffeecard/CoffeeCard.Library/Services/MailgunEmailSender.cs
+++ b/coffeecard/CoffeeCard.Library/Services/MailgunEmailSender.cs
@@ -11,10 +11,8 @@ public class MailgunEmailSender(MailgunSettings mailgunSettings) : IEmailSender
 {
     public async Task SendEmailAsync(MimeMessage mail)
     {
-        var client = new RestClient(mailgunSettings.MailgunApiUrl)
-        {
-            Authenticator = new HttpBasicAuthenticator("api", mailgunSettings.ApiKey)
-        };
+        using var client = new RestClient(mailgunSettings.MailgunApiUrl);
+        client.Authenticator = new HttpBasicAuthenticator("api", mailgunSettings.ApiKey);
 
         var request = new RestRequest();
         request.AddParameter("domain", mailgunSettings.Domain, ParameterType.UrlSegment);

--- a/coffeecard/CoffeeCard.Library/Services/SmtpEmailSender.cs
+++ b/coffeecard/CoffeeCard.Library/Services/SmtpEmailSender.cs
@@ -22,7 +22,7 @@ public class SmtpEmailSender(SmtpSettings smtpSettings) : IEmailSender
         }
         catch (Exception ex)
         {
-            Log.Error($"Error sending mail to SMTP server: {ex.Message}");
+            Log.Error("Error sending request to SMTP server. Error: {errorMessage}", ex.Message);
         }
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/SmtpEmailSender.cs
+++ b/coffeecard/CoffeeCard.Library/Services/SmtpEmailSender.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Threading.Tasks;
 using CoffeeCard.Common.Configuration;
 using MailKit.Net.Smtp;
 using MimeKit;
+using Serilog;
 
 namespace CoffeeCard.Library.Services;
 
@@ -11,9 +13,16 @@ public class SmtpEmailSender(SmtpSettings smtpSettings) : IEmailSender
     {
         mail.From.Add(new MailboxAddress("Cafe Analog", "smtp@analogio.dk"));
 
-        using var smtpClient = new SmtpClient();
-        await smtpClient.ConnectAsync(smtpSettings.Host, smtpSettings.Port);
-        await smtpClient.SendAsync(mail);
-        await smtpClient.DisconnectAsync(true);
+        try
+        {
+            using var smtpClient = new SmtpClient();
+            await smtpClient.ConnectAsync(smtpSettings.Host, smtpSettings.Port);
+            await smtpClient.SendAsync(mail);
+            await smtpClient.DisconnectAsync(true);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Error sending mail to SMTP server: {ex.Message}");
+        }
     }
 }

--- a/coffeecard/CoffeeCard.Library/Services/SmtpEmailSender.cs
+++ b/coffeecard/CoffeeCard.Library/Services/SmtpEmailSender.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using CoffeeCard.Common.Configuration;
+using MailKit.Net.Smtp;
+using MimeKit;
+
+namespace CoffeeCard.Library.Services;
+
+public class SmtpEmailSender(SmtpSettings smtpSettings) : IEmailSender
+{
+    public async Task SendEmailAsync(MimeMessage mail)
+    {
+        mail.From.Add(new MailboxAddress("Cafe Analog", "smtp@analogio.dk"));
+
+        using var smtpClient = new SmtpClient();
+        await smtpClient.ConnectAsync(smtpSettings.Host, smtpSettings.Port);
+        await smtpClient.SendAsync(mail);
+        await smtpClient.DisconnectAsync(true);
+    }
+}

--- a/coffeecard/CoffeeCard.WebApi/Helpers/ConfigurationServiceCollectionExtension.cs
+++ b/coffeecard/CoffeeCard.WebApi/Helpers/ConfigurationServiceCollectionExtension.cs
@@ -24,6 +24,7 @@ namespace CoffeeCard.WebApi.Helpers
             services.ConfigureValidatableSetting<LoginLimiterSettings>(configuration.GetSection("LoginLimiterSettings"));
             services.ConfigureValidatableSetting<IdentitySettings>(configuration.GetSection("IdentitySettings"));
             services.ConfigureValidatableSetting<MailgunSettings>(configuration.GetSection("MailgunSettings"));
+            services.ConfigureValidatableSetting<SmtpSettings>(configuration.GetSection("SmtpSettings"));
             services.ConfigureValidatableSetting<MobilePaySettingsV2>(configuration.GetSection("MobilePaySettingsV2"));
         }
     }

--- a/coffeecard/CoffeeCard.WebApi/Helpers/ConfigurationServiceCollectionExtension.cs
+++ b/coffeecard/CoffeeCard.WebApi/Helpers/ConfigurationServiceCollectionExtension.cs
@@ -24,7 +24,6 @@ namespace CoffeeCard.WebApi.Helpers
             services.ConfigureValidatableSetting<LoginLimiterSettings>(configuration.GetSection("LoginLimiterSettings"));
             services.ConfigureValidatableSetting<IdentitySettings>(configuration.GetSection("IdentitySettings"));
             services.ConfigureValidatableSetting<MailgunSettings>(configuration.GetSection("MailgunSettings"));
-            services.ConfigureValidatableSetting<SmtpSettings>(configuration.GetSection("SmtpSettings"));
             services.ConfigureValidatableSetting<MobilePaySettingsV2>(configuration.GetSection("MobilePaySettingsV2"));
         }
     }

--- a/coffeecard/CoffeeCard.WebApi/Startup.cs
+++ b/coffeecard/CoffeeCard.WebApi/Startup.cs
@@ -76,6 +76,14 @@ namespace CoffeeCard.WebApi
             services.AddScoped<Library.Services.v2.IAccountService, Library.Services.v2.AccountService>();
             services.AddScoped<IPurchaseService, PurchaseService>();
             services.AddScoped<IMapperService, MapperService>();
+            if (_environment.IsDevelopment())
+            {
+                services.AddTransient<IEmailSender, SmtpEmailSender>();
+            }
+            else
+            {
+                services.AddTransient<IEmailSender, MailgunEmailSender>();
+            }
             services.AddScoped<IEmailService, EmailService>();
             services.AddScoped<IVoucherService, VoucherService>();
             services.AddScoped<IProgrammeService, ProgrammeService>();

--- a/coffeecard/CoffeeCard.WebApi/Startup.cs
+++ b/coffeecard/CoffeeCard.WebApi/Startup.cs
@@ -79,6 +79,7 @@ namespace CoffeeCard.WebApi
             if (_environment.IsDevelopment())
             {
                 services.AddTransient<IEmailSender, SmtpEmailSender>();
+                services.AddSingleton(_configuration.GetSection("SmtpSettings").Get<SmtpSettings>());
             }
             else
             {

--- a/coffeecard/CoffeeCard.WebApi/appsettings.json
+++ b/coffeecard/CoffeeCard.WebApi/appsettings.json
@@ -23,6 +23,10 @@
     "EmailBaseUrl": "https://localhost",
     "MailgunApiUrl": "https://api.mailgun.net/v3"
   },
+  "SmtpSettings": {
+    "Host": "mailhog",
+    "Port": 1025
+  },
   "MobilePaySettingsV2": {
     "ApiUrl": "https://invalidurl.test/",
     "ApiKey": "DummyKey",

--- a/coffeecard/docker-compose.yml
+++ b/coffeecard/docker-compose.yml
@@ -35,3 +35,9 @@ services:
     volumes:
       - ./CoffeeCard.WebApi/appsettings.json:/app/appsettings.json:z
       - ~/.aspnet/https:/https:ro
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"


### PR DESCRIPTION
This PR adds an `IEmailSender` abstraction along with implementations `SmtpEmailSender` and `MailgunEmailSender`, and refactors `EmailService` to use said abstraction. The main idea is to allow for local email testing using an SMTP server such as [MailHog](https://github.com/mailhog/MailHog), which has also been added to the Docker Compose configuration.

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/99e86a78-02eb-4e82-bcb8-da70192f6667">
