### PR TITLE
Update SonarCloud workflow, fix .net8 path

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,28 +10,28 @@ jobs:
     name: Configure and scan using SonarCloud
     runs-on: windows-latest
     steps:
-      # Sonarscanner part
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.17
-      - uses: actions/checkout@v3
+          java-version: 17
+          distribution: 'zulu'
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+      - name: Cache SonarQube Cloud packages
+        uses: actions/cache@v4
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache SonarCloud scanner
+      - name: Cache SonarQube Cloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
-      - name: Install SonarCloud scanner
+      - name: Install SonarQube Cloud scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
@@ -49,7 +49,7 @@ jobs:
 
           dotnet build --no-incremental coffeecard/
 
-          coverlet ./coffeecard/CoffeeCard.Tests.Unit/bin/Debug/net6.0/CoffeeCard.Tests.Unit.dll --target "dotnet" --targetargs "test --no-build coffeecard/CoffeeCard.Tests.Unit" -f=opencover -o="coverageunit.xml"
-          coverlet ./coffeecard/CoffeeCard.Tests.Integration/bin/Debug/net6.0/CoffeeCard.Tests.Integration.dll --target "dotnet" --targetargs "test --no-build coffeecard/CoffeeCard.Tests.Integration" -f=opencover -o="coverageintegration.xml"
+          coverlet ./coffeecard/CoffeeCard.Tests.Unit/bin/Debug/net8.0/CoffeeCard.Tests.Unit.dll --target "dotnet" --targetargs "test --no-build coffeecard/CoffeeCard.Tests.Unit" -f=opencover -o="coverageunit.xml"
+          coverlet ./coffeecard/CoffeeCard.Tests.Integration/bin/Debug/net8.0/CoffeeCard.Tests.Integration.dll --target "dotnet" --targetargs "test --no-build coffeecard/CoffeeCard.Tests.Integration" -f=opencover -o="coverageintegration.xml"
 
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
Updates the SonarCloud workflow to some newer versions (mostly taken from the template given by SonarCloud themselves), and hopefully fixes the coverage issue in #298 by fixing the path by changing .net6 -> .net8