### PR TITLE
Changing v2 account service tests to use builders

### DIFF
--- a/coffeecard/CoffeeCard.Library/Services/v2/TokenService.cs
+++ b/coffeecard/CoffeeCard.Library/Services/v2/TokenService.cs
@@ -22,7 +22,7 @@ public class TokenService : ITokenService
     public async Task<string> GenerateMagicLink(User user)
     {
         var guid = Guid.NewGuid().ToString();
-        var magicLinkToken = new Token(guid, TokenType.MagicLink);
+        var magicLinkToken = new Token { TokenHash = guid, Type = TokenType.MagicLink };
 
         user.Tokens.Add(magicLinkToken);
         await _context.SaveChangesAsync();
@@ -33,7 +33,7 @@ public class TokenService : ITokenService
     {
         var refreshToken = Guid.NewGuid().ToString();
         var hashedToken = _hashService.Hash(refreshToken);
-        _context.Tokens.Add(new Token(hashedToken, TokenType.Refresh) { User = user });
+        _context.Tokens.Add(new Token { TokenHash = hashedToken, Type = TokenType.Refresh, User = user });
         await _context.SaveChangesAsync();
         return refreshToken;
     }

--- a/coffeecard/CoffeeCard.Models/Entities/Token.cs
+++ b/coffeecard/CoffeeCard.Models/Entities/Token.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,10 +8,8 @@ namespace CoffeeCard.Models.Entities
     /// <summary>
     /// Shared Token class for different token types
     /// </summary>
-    /// <param name="tokenHash">Hash used to identify the token</param>
-    /// <param name="type"></param>
     [Index(nameof(TokenHash))]
-    public class Token(string tokenHash, TokenType type)
+    public class Token
     {
         /// <summary>
         /// The ID of the token
@@ -20,7 +19,8 @@ namespace CoffeeCard.Models.Entities
         /// <summary>
         /// The randomly generated hash used to find the token
         /// </summary>
-        public string TokenHash { get; set; } = tokenHash;
+        [Required]
+        public required string TokenHash { get; set; }
 
         /// <summary>
         /// The ID of the user that the token is associated with
@@ -39,12 +39,14 @@ namespace CoffeeCard.Models.Entities
         /// <example>
         /// RefreshToken
         /// </example>
-        public TokenType Type { get; set; } = type;
+        [Required]
+        public required TokenType Type { get; set; }
 
         /// <summary>
         /// The date and time when the Token is no longer valid
         /// </summary>
-        public DateTime Expires { get; set; } = type.getExpiresAt();
+        public DateTime Expires
+            => Type.getExpiresAt();
 
         /// <summary>
         /// Whether or not the token has been revoked

--- a/coffeecard/CoffeeCard.Tests.Common/Builders/TokenBuilder.cs
+++ b/coffeecard/CoffeeCard.Tests.Common/Builders/TokenBuilder.cs
@@ -8,7 +8,7 @@ namespace CoffeeCard.Tests.Common.Builders
         public static TokenBuilder Simple()
         {
             return new TokenBuilder()
-                .WithUser(UserBuilder.Simple().Build());
+                .WithUser(UserBuilder.DefaultCustomer().Build());
         }
 
         public static TokenBuilder Typical()


### PR DESCRIPTION
This pull requests addresses @TTA777 review on #289 wrt using test data builders.

This is still a WIP/draft since tests are failing. Please see https://github.com/AnalogIO/analog-core/pull/289#issuecomment-2502152638 for a thorough explanation of the issue.

This PR could also be responsible for adding integration test(s) & addressing the v2 `TokenServiceTests` added in #289 
