### PR TITLE
Add service name to otlp exporter, and enable for dev

### DIFF
--- a/coffeecard/CoffeeCard.WebApi/CoffeeCard.WebApi.csproj
+++ b/coffeecard/CoffeeCard.WebApi/CoffeeCard.WebApi.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Resources.Azure" Version="1.0.0-beta.9" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.3" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />

--- a/coffeecard/CoffeeCard.WebApi/Program.cs
+++ b/coffeecard/CoffeeCard.WebApi/Program.cs
@@ -54,6 +54,7 @@ namespace CoffeeCard.WebApi
                 };
                 var resource = new Dictionary<string, object>();
                 resource.Add("Env", environment.EnvironmentType.ToString() ?? "Env not set");
+                resource.Add("Service.Name", $"analog-core-{environment.EnvironmentType}");
                 loggerConfiguration.WriteTo.OpenTelemetry(settings =>
                 {
                     settings.ResourceAttributes = resource;

--- a/coffeecard/CoffeeCard.WebApi/Startup.cs
+++ b/coffeecard/CoffeeCard.WebApi/Startup.cs
@@ -167,10 +167,16 @@ namespace CoffeeCard.WebApi
                 };
 
                 openTelemetryBuilder.UseOtlpExporter(otlpExportProtocol, new Uri(otlpSettings.Endpoint));
-                openTelemetryBuilder.ConfigureResource(resource => resource.AddAttributes(
-                [
-                    new KeyValuePair<string, object>("Env", environment.EnvironmentType.ToString() ?? "Env not set"),
-                ]));
+                openTelemetryBuilder.ConfigureResource(resource =>
+                {
+                    resource.AddAttributes(
+                    [
+                        new KeyValuePair<string, object>("Env",
+                            environment.EnvironmentType.ToString() ?? "Env not set"),
+                    ]);
+                    resource.AddService($"analog-core-{environment.EnvironmentType}", "analog-core");
+                    resource.AddAzureAppServiceDetector();
+                });
                 if (otlpSettings.Protocol is OtelProtocol.Http)
                 {
                     services.AddHttpClient("OtlpTraceExporter",

--- a/infrastructure/dev.settings.json
+++ b/infrastructure/dev.settings.json
@@ -68,6 +68,14 @@
       {
         "name": "FeatureManagement__MobilePayManageWebhookRegistration",
         "value": true
+      },
+      {
+        "name": "OtlpSettings__Endpoint",
+        "value": "https://otlp-gateway-prod-eu-north-0.grafana.net/otlp"
+      },
+      {
+        "name": "OtlpSettings__Protocol",
+        "value": "http"
       }
     ],
     "keyVaultReferences": [
@@ -102,6 +110,10 @@
       {
         "name": "MobilePaySettings__OcpApimSubscriptionKey",
         "secretName": "MobilePaySettings-OcpApimSubscriptionKey"
+      },
+      {
+        "name": "OtlpSettings__Token",
+        "secretName": "OtlpSettings-Token"
       }
     ]
   }


### PR DESCRIPTION
Set's the service name as part of the telemetry data, as well as a couple of other things from the AzureAppServiceDetector. Also adds setup for dev to use the otlp exporter. 

Appropriate secret has already been created in keyvault.