### PR TITLE
Minor fixes for otel serivce name

### DIFF
--- a/coffeecard/CoffeeCard.WebApi/Program.cs
+++ b/coffeecard/CoffeeCard.WebApi/Program.cs
@@ -54,7 +54,7 @@ namespace CoffeeCard.WebApi
                 };
                 var resource = new Dictionary<string, object>();
                 resource.Add("Env", environment.EnvironmentType.ToString() ?? "Env not set");
-                resource.Add("Service.Name", $"analog-core-{environment.EnvironmentType}");
+                resource.Add("service.name", $"analog-core-{environment.EnvironmentType}");
                 loggerConfiguration.WriteTo.OpenTelemetry(settings =>
                 {
                     settings.ResourceAttributes = resource;

--- a/coffeecard/CoffeeCard.WebApi/Startup.cs
+++ b/coffeecard/CoffeeCard.WebApi/Startup.cs
@@ -174,8 +174,8 @@ namespace CoffeeCard.WebApi
                         new KeyValuePair<string, object>("Env",
                             environment.EnvironmentType.ToString() ?? "Env not set"),
                     ]);
-                    resource.AddService($"analog-core-{environment.EnvironmentType}", "analog-core");
                     resource.AddAzureAppServiceDetector();
+                    resource.AddService($"analog-core-{environment.EnvironmentType}", "analog-core");
                 });
                 if (otlpSettings.Protocol is OtelProtocol.Http)
                 {


### PR DESCRIPTION
- The grafana collector for otel is caps sensitive, so does not map the Service.Name to service_name field. Now corrected
- Reversed the order of registration for AddService and AddAzureAppServiceDetector, so we overrite the detector, and not the other way around