### PR TITLE
Add proper logging of request object for webhook endpoint

### DIFF
--- a/coffeecard/CoffeeCard.WebApi/Controllers/v2/MobilePayController.cs
+++ b/coffeecard/CoffeeCard.WebApi/Controllers/v2/MobilePayController.cs
@@ -73,7 +73,7 @@ public class MobilePayController : ControllerBase
             return BadRequest("Could not verify signature");
         }
 
-        _logger.LogInformation("MobilePay Webhook invoked with request: '{Request}'", request);
+        _logger.LogInformation("MobilePay Webhook invoked with request: '{@Request}'", request);
         await _purchaseService.HandleMobilePayPaymentUpdate(request);
 
         return NoContent();


### PR DESCRIPTION
Changes logging to use json serilization instead of standard toString method for logging the incoming request